### PR TITLE
Add the ability to navigate the calendar by a custom amount of time units

### DIFF
--- a/XCalendar/CalendarView.xaml
+++ b/XCalendar/CalendarView.xaml
@@ -21,6 +21,8 @@
 
             <xct:EnumToBoolConverter x:Key="EnumToBoolConverter" />
 
+            <xct:MathExpressionConverter x:Key="MathExpressionConverter"/>
+
             <xct:MultiConverter x:Key="EnumToStringCharLimitConverter">
                 <Converters:EnumToStringConverter />
                 <Converters:StringCharLimitConverter />
@@ -41,15 +43,12 @@
                 <Frame
                     Padding="5"
                     xct:TouchEffect.Command="{Binding NavigateCalendarCommand, Source={x:Reference MainCalendarView}}"
+                    xct:TouchEffect.CommandParameter="{Binding BackwardsNavigationAmount, Source={x:Reference MainCalendarView}}"
                     xct:TouchEffect.NativeAnimation="True"
                     BackgroundColor="{Binding NavigationArrowBackgroundColor, Source={x:Reference MainCalendarView}}"
                     CornerRadius="{Binding NavigationArrowCornerRadius, Source={x:Reference MainCalendarView}}"
                     HorizontalOptions="CenterAndExpand"
                     VerticalOptions="Center">
-
-                    <xct:TouchEffect.CommandParameter>
-                        <x:Int32>-1</x:Int32>
-                    </xct:TouchEffect.CommandParameter>
 
                     <Label
                         FontAttributes="Bold"
@@ -72,15 +71,12 @@
                 <Frame
                     Padding="5"
                     xct:TouchEffect.Command="{Binding NavigateCalendarCommand, Source={x:Reference MainCalendarView}}"
+                    xct:TouchEffect.CommandParameter="{Binding ForwardsNavigationAmount, Source={x:Reference MainCalendarView}}"
                     xct:TouchEffect.NativeAnimation="True"
                     BackgroundColor="{Binding NavigationArrowBackgroundColor, Source={x:Reference MainCalendarView}}"
                     CornerRadius="{Binding NavigationArrowCornerRadius, Source={x:Reference MainCalendarView}}"
                     HorizontalOptions="CenterAndExpand"
                     VerticalOptions="Center">
-
-                    <xct:TouchEffect.CommandParameter>
-                        <x:Int32>1</x:Int32>
-                    </xct:TouchEffect.CommandParameter>
 
                     <Label
                         FontAttributes="Bold"

--- a/XCalendar/CalendarView.xaml
+++ b/XCalendar/CalendarView.xaml
@@ -41,12 +41,15 @@
                 <Frame
                     Padding="5"
                     xct:TouchEffect.Command="{Binding NavigateCalendarCommand, Source={x:Reference MainCalendarView}}"
-                    xct:TouchEffect.CommandParameter="{StaticResource FalseValue}"
                     xct:TouchEffect.NativeAnimation="True"
                     BackgroundColor="{Binding NavigationArrowBackgroundColor, Source={x:Reference MainCalendarView}}"
                     CornerRadius="{Binding NavigationArrowCornerRadius, Source={x:Reference MainCalendarView}}"
                     HorizontalOptions="CenterAndExpand"
                     VerticalOptions="Center">
+
+                    <xct:TouchEffect.CommandParameter>
+                        <x:Int32>-1</x:Int32>
+                    </xct:TouchEffect.CommandParameter>
 
                     <Label
                         FontAttributes="Bold"
@@ -69,12 +72,15 @@
                 <Frame
                     Padding="5"
                     xct:TouchEffect.Command="{Binding NavigateCalendarCommand, Source={x:Reference MainCalendarView}}"
-                    xct:TouchEffect.CommandParameter="{StaticResource TrueValue}"
                     xct:TouchEffect.NativeAnimation="True"
                     BackgroundColor="{Binding NavigationArrowBackgroundColor, Source={x:Reference MainCalendarView}}"
                     CornerRadius="{Binding NavigationArrowCornerRadius, Source={x:Reference MainCalendarView}}"
                     HorizontalOptions="CenterAndExpand"
                     VerticalOptions="Center">
+
+                    <xct:TouchEffect.CommandParameter>
+                        <x:Int32>1</x:Int32>
+                    </xct:TouchEffect.CommandParameter>
 
                     <Label
                         FontAttributes="Bold"

--- a/XCalendar/CalendarView.xaml.cs
+++ b/XCalendar/CalendarView.xaml.cs
@@ -295,7 +295,7 @@ namespace XCalendar
         /// <summary>
         /// How the calendar handles navigation past the <see cref="DateTime.MinValue"/>, <see cref="DateTime.MaxValue"/>, <see cref="DayRangeMinimumDate"/>, and <see cref="DayRangeMaximumDate"/>.
         /// </summary>
-        /// <seealso cref="NavigateCalendar(bool)"/>
+        /// <seealso cref="NavigateCalendar(int)"/>
         public NavigationLoopMode NavigationLoopMode
         {
             get { return (NavigationLoopMode)GetValue(NavigationLoopModeProperty); }
@@ -345,7 +345,7 @@ namespace XCalendar
             set { SetValue(DayTemplateProperty, value); }
         }
         /// <summary>
-        /// The amount that the source date will change when navigating using <see cref="NavigateCalendar(bool)"/>.
+        /// The amount that the source date will change when navigating using <see cref="NavigateCalendar(int)"/>.
         /// </summary>
         public NavigationTimeUnit NavigationTimeUnit
         {
@@ -511,7 +511,7 @@ namespace XCalendar
         #region Constructors
         public CalendarView()
         {
-            NavigateCalendarCommand = new Command<bool>(NavigateCalendar);
+            NavigateCalendarCommand = new Command<int>(NavigateCalendar);
             ChangeDateSelectionCommand = new Command<DateTime>(ChangeDateSelection);
 
             List<DayOfWeek> InitialStartOfWeekDayNamesOrder = new List<DayOfWeek>();
@@ -685,12 +685,12 @@ namespace XCalendar
         /// </summary>
         /// <param name="Forward">Whether the source will be navigated forwards or backwards</param>
         /// <exception cref="NotImplementedException">The current <see cref="PageStartMode"/> is not implemented</exception>
-        public virtual void NavigateCalendar(bool Forward)
+        public virtual void NavigateCalendar(int Amount)
         {
             DateTime MinimumDate = ClampNavigationToDayRange ? DayRangeMinimumDate : DateTime.MinValue;
             DateTime MaximumDate = ClampNavigationToDayRange ? DayRangeMaximumDate : DateTime.MaxValue;
 
-            NavigatedDate = NavigateDateTime(NavigatedDate, MinimumDate, MaximumDate, Forward ? 1 : -1, NavigationLoopMode, NavigationTimeUnit, StartOfWeek);
+            NavigatedDate = NavigateDateTime(NavigatedDate, MinimumDate, MaximumDate, Amount, NavigationLoopMode, NavigationTimeUnit, StartOfWeek);
         }
         /// <summary>
         /// Performs navigation on a DateTime.

--- a/XCalendar/CalendarView.xaml.cs
+++ b/XCalendar/CalendarView.xaml.cs
@@ -727,6 +727,10 @@ namespace XCalendar
             {
                 switch (NavigationTimeUnit)
                 {
+                    case NavigationTimeUnit.Day:
+                        NewNavigatedDate = DateTime.AddDays(Amount);
+                        break;
+
                     case NavigationTimeUnit.Week:
                         NewNavigatedDate = DateTime.AddWeeks(Amount);
                         break;

--- a/XCalendar/CalendarView.xaml.cs
+++ b/XCalendar/CalendarView.xaml.cs
@@ -727,10 +727,6 @@ namespace XCalendar
             {
                 switch (NavigationTimeUnit)
                 {
-                    case NavigationTimeUnit.None:
-                        NewNavigatedDate = DateTime;
-                        break;
-
                     case NavigationTimeUnit.Week:
                         NewNavigatedDate = DateTime.AddWeeks(Amount);
                         break;
@@ -741,10 +737,6 @@ namespace XCalendar
 
                     case NavigationTimeUnit.Year:
                         NewNavigatedDate = DateTime.AddYears(Amount);
-                        break;
-
-                    case NavigationTimeUnit.Page:
-                        NewNavigatedDate = DateTime.AddWeeks(Rows * Amount);
                         break;
 
                     default:

--- a/XCalendar/CalendarView.xaml.cs
+++ b/XCalendar/CalendarView.xaml.cs
@@ -423,6 +423,16 @@ namespace XCalendar
             get { return (float)GetValue(DayCornerRadiusProperty); }
             set { SetValue(DayCornerRadiusProperty, value); }
         }
+        public int ForwardsNavigationAmount
+        {
+            get { return (int)GetValue(ForwardsNavigationAmountProperty); }
+            set { SetValue(ForwardsNavigationAmountProperty, value); }
+        }
+        public int BackwardsNavigationAmount
+        {
+            get { return (int)GetValue(BackwardsNavigationAmountProperty); }
+            set { SetValue(BackwardsNavigationAmountProperty, value); }
+        }
 
         #region Bindable Properties Initialisers
         public static readonly BindableProperty NavigatedDateProperty = BindableProperty.Create(nameof(NavigatedDate), typeof(DateTime), typeof(CalendarView), DateTime.Now, defaultBindingMode: BindingMode.TwoWay, propertyChanged: NavigatedDatePropertyChanged, coerceValue: CoerceNavigatedDate);
@@ -484,6 +494,8 @@ namespace XCalendar
         public static readonly BindableProperty NavigationArrowCornerRadiusProperty = BindableProperty.Create(nameof(NavigationArrowCornerRadius), typeof(float), typeof(CalendarView), 100f);
         public static readonly BindableProperty NavigationLoopModeProperty = BindableProperty.Create(nameof(NavigationLoopMode), typeof(NavigationLoopMode), typeof(CalendarView), NavigationLoopMode.LoopMinimumAndMaximum);
         public static readonly BindableProperty NavigationTimeUnitProperty = BindableProperty.Create(nameof(NavigationTimeUnit), typeof(NavigationTimeUnit), typeof(CalendarView), NavigationTimeUnit.Month);
+        public static readonly BindableProperty ForwardsNavigationAmountProperty = BindableProperty.Create(nameof(ForwardsNavigationAmount), typeof(int), typeof(CalendarView), 1);
+        public static readonly BindableProperty BackwardsNavigationAmountProperty = BindableProperty.Create(nameof(BackwardsNavigationAmount), typeof(int), typeof(CalendarView), -1);
         public static readonly BindableProperty PageStartModeProperty = BindableProperty.Create(nameof(PageStartMode), typeof(PageStartMode), typeof(CalendarView), PageStartMode.FirstDayOfMonth, propertyChanged: PageStartModePropertyChanged);
         public static readonly BindableProperty ClampNavigationToDayRangeProperty = BindableProperty.Create(nameof(ClampNavigationToDayRange), typeof(bool), typeof(CalendarView), true, propertyChanged: ClampNavigationToDayRangePropertyChanged);
         #endregion

--- a/XCalendar/Enums/NavigationTimeUnit.cs
+++ b/XCalendar/Enums/NavigationTimeUnit.cs
@@ -2,6 +2,7 @@
 {
     public enum NavigationTimeUnit
     {
+        Day,
         Week,
         Month,
         Year

--- a/XCalendar/Enums/NavigationTimeUnit.cs
+++ b/XCalendar/Enums/NavigationTimeUnit.cs
@@ -2,10 +2,8 @@
 {
     public enum NavigationTimeUnit
     {
-        None,
         Week,
         Month,
-        Year,
-        Page
+        Year
     }
 }

--- a/XCalendarSample/XCalendarSample/ViewModels/MainPageViewModel.cs
+++ b/XCalendarSample/XCalendarSample/ViewModels/MainPageViewModel.cs
@@ -58,6 +58,8 @@ namespace XCalendarSample.ViewModels
         public DateTime TodayDate { get; set; } = DateTime.Today;
         public bool ClampNavigationToDayRange { get; set; } = true;
         public double NavigationHeightRequest { get; set; } = 40;
+        public int ForwardsNavigationAmount { get; set; } = 1;
+        public int BackwardsNavigationAmount { get; set; } = -1;
         #endregion
 
         #region Commands

--- a/XCalendarSample/XCalendarSample/Views/MainPage.xaml
+++ b/XCalendarSample/XCalendarSample/Views/MainPage.xaml
@@ -304,6 +304,34 @@
                                 Grid.Column="0"
                                 FontSize="{StaticResource SmallFontSize}"
                                 HorizontalTextAlignment="Center"
+                                Text="Forwards&#10;NavigationAmount"
+                                VerticalTextAlignment="Center" />
+                            <Editor
+                                Grid.Column="1"
+                                HorizontalOptions="Center"
+                                Text="{Binding ForwardsNavigationAmount}"
+                                VerticalOptions="End" />
+                        </Grid>
+
+                        <Grid>
+                            <Label
+                                Grid.Column="0"
+                                FontSize="{StaticResource SmallFontSize}"
+                                HorizontalTextAlignment="Center"
+                                Text="Backwards&#10;NavigationAmount"
+                                VerticalTextAlignment="Center" />
+                            <Editor
+                                Grid.Column="1"
+                                HorizontalOptions="Center"
+                                Text="{Binding BackwardsNavigationAmount}"
+                                VerticalOptions="End" />
+                        </Grid>
+
+                        <Grid>
+                            <Label
+                                Grid.Column="0"
+                                FontSize="{StaticResource SmallFontSize}"
+                                HorizontalTextAlignment="Center"
                                 Text="NavigationTimeUnit"
                                 VerticalTextAlignment="Center" />
                             <Label
@@ -543,6 +571,7 @@
                         AutoRows="{Binding AutoRows}"
                         AutoRowsIsConsistent="{Binding AutoRowsIsConsistent}"
                         BackgroundColor="{StaticResource ContentBackgroundColor}"
+                        BackwardsNavigationAmount="{Binding BackwardsNavigationAmount}"
                         ClampNavigationToDayRange="{Binding ClampNavigationToDayRange}"
                         CustomDayNamesOrder="{Binding CustomDayNamesOrder}"
                         DayCurrentMonthTextColor="{StaticResource ContentTextColor}"
@@ -557,6 +586,7 @@
                         DayTodayBorderColor="{StaticResource PrimaryColor}"
                         DayTodayTextColor="{StaticResource ContentTextColor}"
                         DayWidthRequest="{Binding DayWidthRequest}"
+                        ForwardsNavigationAmount="{Binding ForwardsNavigationAmount}"
                         MonthViewHeightRequest="{Binding MonthViewHeightRequest}"
                         NavigatedDate="{Binding NavigatedDate}"
                         NavigationArrowColor="{StaticResource ContentTextColor}"


### PR DESCRIPTION
For example:
NavigationTimeUnit = Week and ForwardsNavigationAmount = 3 would mean the calendar navigates 3 weeks forward.
NavigationTimeUnit = Week and BackwardsNavigationAmount = 3 would mean the calendar navigates 3 weeks backward.