### PR TITLE
Rework date selection

### DIFF
--- a/XCalendar/CalendarDayView.xaml.cs
+++ b/XCalendar/CalendarDayView.xaml.cs
@@ -308,16 +308,7 @@ namespace XCalendar
         }
         public virtual bool IsDateTimeSelected(DateTime DateTime)
         {
-            switch (CalendarView?.SelectionMode)
-            {
-                case null:
-                case Enums.SelectionMode.None: return false;
-                case Enums.SelectionMode.Single: return CalendarView?.SelectedDate?.Date == DateTime.Date;
-                case Enums.SelectionMode.Multiple:
-                case Enums.SelectionMode.Range: return CalendarView?.SelectedDates?.Any(x => x.Date == DateTime.Date) == true;
-                default:
-                    throw new NotImplementedException($"{nameof(Enums.SelectionMode)} is not implemented.");
-            }
+            return CalendarView?.SelectedDates.Any(x => x.Date == DateTime.Date) == true;
         }
         protected override void OnBindingContextChanged()
         {

--- a/XCalendar/CalendarView.xaml
+++ b/XCalendar/CalendarView.xaml
@@ -176,7 +176,7 @@
                                                     <Style.Triggers>
                                                         <MultiTrigger TargetType="{x:Type xc:CalendarDayView}">
                                                             <MultiTrigger.Conditions>
-                                                                <BindingCondition Binding="{Binding SelectionMode, Source={x:Reference MainCalendarView}, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static Enums:SelectionMode.None}}" Value="False" />
+                                                                <BindingCondition Binding="{Binding SelectionType, Source={x:Reference MainCalendarView}, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static Enums:SelectionType.None}}" Value="False" />
                                                                 <BindingCondition Binding="{Binding IsCurrentMonth, Source={RelativeSource Self}}" Value="True" />
                                                                 <BindingCondition Binding="{Binding IsOutOfRange, Source={RelativeSource Self}}" Value="False" />
                                                             </MultiTrigger.Conditions>

--- a/XCalendar/CalendarView.xaml.cs
+++ b/XCalendar/CalendarView.xaml.cs
@@ -31,6 +31,7 @@ namespace XCalendar
 
         private readonly ObservableCollection<CalendarDay> _Days = new ObservableCollection<CalendarDay>();
         private readonly ObservableRangeCollection<DayOfWeek> _StartOfWeekDayNamesOrder = new ObservableRangeCollection<DayOfWeek>();
+        private readonly List<DateTime> _PreviousSelectedDates = new List<DateTime>();
         #endregion
 
         #region Properties
@@ -884,29 +885,10 @@ namespace XCalendar
         {
             OnMonthViewDaysInvalidated();
 
-            //Calculating the Previous selection.
-            List<DateTime> PreviousSelection = SelectedDates.ToList();
+            OnDateSelectionChanged(_PreviousSelectedDates, SelectedDates);
 
-            if (e.OldItems != null && e.NewItems != null)
-            {
-                PreviousSelection = e.OldItems.Cast<DateTime>().ToList();
-            }
-            else if (e.OldItems != null)
-            {
-                PreviousSelection.AddRange(e.OldItems.Cast<DateTime>());
-            }
-            else if (e.NewItems != null)
-            {
-                for (int i = 0; i < e.NewItems.Count; i++)
-                {
-                    PreviousSelection.RemoveAll(x => x == (DateTime)e.NewItems[i]);
-                }
-            }
-            else
-            {
-                PreviousSelection = new List<DateTime>();
-            }
-            OnDateSelectionChanged(PreviousSelection, SelectedDates);
+            _PreviousSelectedDates.Clear();
+            _PreviousSelectedDates.AddRange(SelectedDates.ToList());
         }
         private void DayNamesOrder_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
@@ -1000,10 +982,13 @@ namespace XCalendar
             if (OldSelectedDates != null) { OldSelectedDates.CollectionChanged -= Control.SelectedDates_CollectionChanged; }
             if (NewSelectedDates != null) { NewSelectedDates.CollectionChanged += Control.SelectedDates_CollectionChanged; }
 
+            Control._PreviousSelectedDates.Clear();
+            Control._PreviousSelectedDates.AddRange(OldSelectedDates);
+
             if (!OldSelectedDates.SequenceEqual(NewSelectedDates))
             {
                 Control.OnMonthViewDaysInvalidated();
-                Control.OnDateSelectionChanged(OldSelectedDates, NewSelectedDates);
+                Control.OnDateSelectionChanged(Control._PreviousSelectedDates, NewSelectedDates);
             }
         }
         private static void CustomDayNamesOrderPropertyChanged(BindableObject bindable, object oldValue, object newValue)

--- a/XCalendar/Enums/SelectionMode.cs
+++ b/XCalendar/Enums/SelectionMode.cs
@@ -2,9 +2,9 @@
 {
     public enum SelectionMode
     {
-        None,
-        Single,
-        Multiple,
-        Range
+        Add,
+        Remove,
+        Modify,
+        Replace
     }
 }

--- a/XCalendar/Enums/SelectionType.cs
+++ b/XCalendar/Enums/SelectionType.cs
@@ -1,0 +1,9 @@
+﻿namespace XCalendar.Enums
+{
+    public enum SelectionType
+    {
+        None,
+        Single,
+        Range
+    }
+}

--- a/XCalendarSample/XCalendarSample/ViewModels/MainPageViewModel.cs
+++ b/XCalendarSample/XCalendarSample/ViewModels/MainPageViewModel.cs
@@ -13,7 +13,6 @@ namespace XCalendarSample.ViewModels
     public class MainPageViewModel : BaseViewModel
     {
         #region Properties
-        public DateTime? SelectedDate { get; set; }
         public ObservableRangeCollection<DateTime> SelectedDates { get; } = new ObservableRangeCollection<DateTime>();
         public List<XCalendar.Enums.SelectionMode> SelectionModes { get; set; } = Enum.GetValues(typeof(XCalendar.Enums.SelectionMode)).Cast<XCalendar.Enums.SelectionMode>().ToList();
         public List<PageStartMode> PageStartModes { get; set; } = Enum.GetValues(typeof(PageStartMode)).Cast<PageStartMode>().ToList();

--- a/XCalendarSample/XCalendarSample/ViewModels/MainPageViewModel.cs
+++ b/XCalendarSample/XCalendarSample/ViewModels/MainPageViewModel.cs
@@ -14,6 +14,7 @@ namespace XCalendarSample.ViewModels
     {
         #region Properties
         public ObservableRangeCollection<DateTime> SelectedDates { get; } = new ObservableRangeCollection<DateTime>();
+        public List<SelectionType> SelectionTypes { get; set; } = Enum.GetValues(typeof(SelectionType)).Cast<SelectionType>().ToList();
         public List<XCalendar.Enums.SelectionMode> SelectionModes { get; set; } = Enum.GetValues(typeof(XCalendar.Enums.SelectionMode)).Cast<XCalendar.Enums.SelectionMode>().ToList();
         public List<PageStartMode> PageStartModes { get; set; } = Enum.GetValues(typeof(PageStartMode)).Cast<PageStartMode>().ToList();
         public List<NavigationTimeUnit> NavigationTimeUnits { get; set; } = Enum.GetValues(typeof(NavigationTimeUnit)).Cast<NavigationTimeUnit>().ToList();
@@ -42,8 +43,9 @@ namespace XCalendarSample.ViewModels
             DayOfWeek.Saturday,
             DayOfWeek.Sunday
         };
-        public XCalendar.Enums.SelectionMode SelectionMode { get; set; } = XCalendar.Enums.SelectionMode.Multiple;
+        public XCalendar.Enums.SelectionMode SelectionMode { get; set; } = XCalendar.Enums.SelectionMode.Modify;
         public NavigationLoopMode NavigationLoopMode { get; set; } = NavigationLoopMode.LoopMinimumAndMaximum;
+        public SelectionType SelectionType { get; set; } = SelectionType.Single;
         public NavigationTimeUnit NavigationTimeUnit { get; set; } = NavigationTimeUnit.Month;
         public PageStartMode PageStartMode { get; set; } = PageStartMode.FirstDayOfMonth;
         public int Rows { get; set; } = 2;
@@ -68,6 +70,7 @@ namespace XCalendarSample.ViewModels
         public ICommand ShowNavigationTimeUnitDialogCommand { get; set; }
         public ICommand ShowPageStartModeDialogCommand { get; set; }
         public ICommand ShowStartOfWeekDialogCommand { get; set; }
+        public ICommand ShowSelectionTypeDialogCommand { get; set; }
         #endregion
 
         #region Constructors
@@ -79,6 +82,7 @@ namespace XCalendarSample.ViewModels
             ShowNavigationTimeUnitDialogCommand = new Command(ShowNavigationTimeUnitDialog);
             ShowPageStartModeDialogCommand = new Command(ShowPageStartModeDialog);
             ShowStartOfWeekDialogCommand = new Command(ShowStartOfWeekDialog);
+            ShowSelectionTypeDialogCommand = new Command(ShowSelectionTypeDialog);
         }
         #endregion
 
@@ -107,6 +111,10 @@ namespace XCalendarSample.ViewModels
         public async void ShowStartOfWeekDialog()
         {
             StartOfWeek = (DayOfWeek)await Application.Current.MainPage.ShowPopupAsync(new SelectItemDialogPopup(StartOfWeek, DaysOfWeek));
+        }
+        public async void ShowSelectionTypeDialog()
+        {
+            SelectionType = (SelectionType)await Application.Current.MainPage.ShowPopupAsync(new SelectItemDialogPopup(SelectionType, SelectionTypes));
         }
         #endregion
     }

--- a/XCalendarSample/XCalendarSample/Views/MainPage.xaml
+++ b/XCalendarSample/XCalendarSample/Views/MainPage.xaml
@@ -260,6 +260,24 @@
                                 Grid.Column="0"
                                 FontSize="{StaticResource SmallFontSize}"
                                 HorizontalTextAlignment="Center"
+                                Text="SelectionType"
+                                VerticalTextAlignment="Center" />
+                            <Label
+                                Grid.Column="1"
+                                xct:TouchEffect.Command="{Binding ShowSelectionTypeDialogCommand}"
+                                xct:TouchEffect.NativeAnimation="True"
+                                FontSize="{StaticResource SmallFontSize}"
+                                HorizontalTextAlignment="Center"
+                                Text="{Binding SelectionType}"
+                                TextColor="#0080E0"
+                                VerticalTextAlignment="Center" />
+                        </Grid>
+
+                        <Grid>
+                            <Label
+                                Grid.Column="0"
+                                FontSize="{StaticResource SmallFontSize}"
+                                HorizontalTextAlignment="Center"
                                 Text="SelectionMode"
                                 VerticalTextAlignment="Center" />
                             <Label
@@ -572,6 +590,7 @@
                         Rows="{Binding Rows}"
                         SelectedDates="{Binding SelectedDates}"
                         SelectionMode="{Binding SelectionMode}"
+                        SelectionType="{Binding SelectionType}"
                         StartOfWeek="{Binding StartOfWeek}"
                         TodayDate="{Binding TodayDate}"
                         UseCustomDayNamesOrder="{Binding UseCustomDayNamesOrder}">
@@ -615,7 +634,7 @@
                                                             <Style.Triggers>
                                                                 <MultiTrigger TargetType="{x:Type xc:CalendarDayView}">
                                                                     <MultiTrigger.Conditions>
-                                                                        <BindingCondition Binding="{Binding SelectionMode, Source={x:Reference FancyCalendarView}, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static Enums:SelectionMode.None}}" Value="False" />
+                                                                        <BindingCondition Binding="{Binding SelectionType, Source={x:Reference FancyCalendarView}, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static Enums:SelectionType.None}}" Value="False" />
                                                                         <BindingCondition Binding="{Binding IsCurrentMonth, Source={RelativeSource Self}}" Value="True" />
                                                                         <BindingCondition Binding="{Binding IsOutOfRange, Source={RelativeSource Self}}" Value="False" />
                                                                     </MultiTrigger.Conditions>

--- a/XCalendarSample/XCalendarSample/Views/MainPage.xaml
+++ b/XCalendarSample/XCalendarSample/Views/MainPage.xaml
@@ -232,32 +232,6 @@
                                 Grid.Column="0"
                                 FontSize="{StaticResource SmallFontSize}"
                                 HorizontalTextAlignment="Center"
-                                Text="SelectedDate"
-                                VerticalTextAlignment="Center" />
-                            <Editor
-                                Grid.Column="1"
-                                AutoSize="TextChanges"
-                                FontSize="{StaticResource SmallFontSize}"
-                                HorizontalOptions="Center"
-                                Text="{Binding SelectedDate, StringFormat='{0:ddd, MMM yyy}'}"
-                                TextColor="{StaticResource ContentTextColor}"
-                                VerticalOptions="End" />
-                            <DatePicker
-                                Grid.Column="1"
-                                Date="{Binding SelectedDate}"
-                                FontSize="{StaticResource SmallFontSize}"
-                                Format="ddd, MMM yyy"
-                                HorizontalOptions="Center"
-                                MaximumDate="{x:Static System:DateTime.MaxValue}"
-                                MinimumDate="{x:Static System:DateTime.MinValue}"
-                                TextColor="Transparent" />
-                        </Grid>
-
-                        <Grid>
-                            <Label
-                                Grid.Column="0"
-                                FontSize="{StaticResource SmallFontSize}"
-                                HorizontalTextAlignment="Center"
                                 Text="SelectedDates"
                                 VerticalTextAlignment="Center" />
                             <CollectionView
@@ -596,7 +570,6 @@
                         NavigationTimeUnit="{Binding NavigationTimeUnit}"
                         PageStartMode="{Binding PageStartMode}"
                         Rows="{Binding Rows}"
-                        SelectedDate="{Binding SelectedDate}"
                         SelectedDates="{Binding SelectedDates}"
                         SelectionMode="{Binding SelectionMode}"
                         StartOfWeek="{Binding StartOfWeek}"


### PR DESCRIPTION
Unifiy `SelectedDate` into `SelectedDates`.

Separate *how* the user selects a date from *what happens* when the user selects a date. For example:
* Separating `SelectionMode.Single` into `SelectionType.Single` and `SelectionMode.Replace`
* Separating `SelectionMode.Multiple` into `SelectionType.Single` and `SelectionMode.Modify`
* Separating `SelectionMode.Range` into `SelectionType.Range` and `SelectionMode.Replace`