### PR TITLE
Remove StartOfWeekDayNamesOrder

### DIFF
--- a/XCalendar/Extensions/DateTimeExtensions.cs
+++ b/XCalendar/Extensions/DateTimeExtensions.cs
@@ -4,8 +4,9 @@ using System.Globalization;
 
 namespace XCalendar.Extensions
 {
-    public static partial class DateTimeExtensions
+    public static class DateTimeExtensions
     {
+        #region Methods
         /// <summary>
         /// Returns a new <see cref="DateTime"/> that adds the specified number of weeks to the value of instance.
         /// </summary>
@@ -515,5 +516,6 @@ namespace XCalendar.Extensions
 
             return DateTimes;
         }
+        #endregion
     }
 }

--- a/XCalendar/Extensions/DayOfWeekExtensionscs.cs
+++ b/XCalendar/Extensions/DayOfWeekExtensionscs.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+
+namespace XCalendar.Extensions
+{
+    public static class DayOfWeekExtensions
+    {
+        #region Properties
+        public static readonly ReadOnlyCollection<DayOfWeek> DaysOfWeek = new List<DayOfWeek>()
+        {
+            DayOfWeek.Monday,
+            DayOfWeek.Tuesday,
+            DayOfWeek.Wednesday,
+            DayOfWeek.Thursday,
+            DayOfWeek.Friday,
+            DayOfWeek.Saturday,
+            DayOfWeek.Sunday
+        }.AsReadOnly();
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Gets a chronological list of every <see cref="DayOfWeek"/> in which the first element is this instance.
+        /// </summary>
+        public static List<DayOfWeek> GetWeekAsFirst(this DayOfWeek Self)
+        {
+            List<DayOfWeek> Week = new List<DayOfWeek>();
+            int StartOfWeekIndex = DaysOfWeek.IndexOf(Self);
+
+            for (int i = StartOfWeekIndex; Week.Count != DaysOfWeek.Count; i = i < DaysOfWeek.Count - 1 ? i + 1 : 0)
+            {
+                Week.Add(DaysOfWeek[i]);
+            }
+
+            return Week;
+        }
+        /// <summary>
+        /// Gets a chronological list of every <see cref="DayOfWeek"/> in which the last element is this instance.
+        /// </summary>
+        public static List<DayOfWeek> GetWeekAsLast(this DayOfWeek Self)
+        {
+            List<DayOfWeek> Week = new List<DayOfWeek>();
+            int StartOfWeekIndex = DaysOfWeek.IndexOf(Self) + 1;
+
+            if (StartOfWeekIndex == DaysOfWeek.Count)
+            {
+                StartOfWeekIndex = 0;
+            }
+
+            for (int i = StartOfWeekIndex; Week.Count != DaysOfWeek.Count; i = i < DaysOfWeek.Count - 1 ? i + 1 : 0)
+            {
+                Week.Add(DaysOfWeek[i]);
+            }
+
+            return Week;
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
Not needed anymore because `DayOfWeekExtensions.GetWeekAsFirst` can be used on the `StartOfWeek` to get the same value.