### PR TITLE
Clearer navigation properties

### DIFF
--- a/XCalendar.Forms/Enums/DayState.cs
+++ b/XCalendar.Forms/Enums/DayState.cs
@@ -6,6 +6,6 @@
         OtherMonth,
         Today,
         Selected,
-        OutOfRange
+        Invalid
     }
 }

--- a/XCalendar.Forms/Views/CalendarDayView.xaml.cs
+++ b/XCalendar.Forms/Views/CalendarDayView.xaml.cs
@@ -349,7 +349,7 @@ namespace XCalendar.Forms.Views
         }
         public virtual bool IsDateTimeOutOfRange(DateTime DateTime)
         {
-            return DateTime.Date < CalendarView?.NavigationLowerBound.Date || DateTime.Date > CalendarView?.DayRangeMaximumDate.Date;
+            return DateTime.Date < CalendarView?.NavigationLowerBound.Date || DateTime.Date > CalendarView?.NavigationUpperBound.Date;
         }
         public virtual bool IsDateTimeToday(DateTime DateTime)
         {

--- a/XCalendar.Forms/Views/CalendarDayView.xaml.cs
+++ b/XCalendar.Forms/Views/CalendarDayView.xaml.cs
@@ -349,7 +349,7 @@ namespace XCalendar.Forms.Views
         }
         public virtual bool IsDateTimeOutOfRange(DateTime DateTime)
         {
-            return DateTime.Date < CalendarView?.DayRangeMinimumDate.Date || DateTime.Date > CalendarView?.DayRangeMaximumDate.Date;
+            return DateTime.Date < CalendarView?.NavigationLowerBound.Date || DateTime.Date > CalendarView?.DayRangeMaximumDate.Date;
         }
         public virtual bool IsDateTimeToday(DateTime DateTime)
         {

--- a/XCalendar.Forms/Views/CalendarDayView.xaml.cs
+++ b/XCalendar.Forms/Views/CalendarDayView.xaml.cs
@@ -38,10 +38,10 @@ namespace XCalendar.Forms.Views
             get { return (bool)GetValue(IsSelectedProperty); }
             set { SetValue(IsSelectedProperty, value); }
         }
-        public bool IsOutOfRange
+        public bool IsInvalid
         {
-            get { return (bool)GetValue(IsOutOfRangeProperty); }
-            set { SetValue(IsOutOfRangeProperty, value); }
+            get { return (bool)GetValue(IsInvalidProperty); }
+            set { SetValue(IsInvalidProperty, value); }
         }
         public bool IsDayStateCurrentMonth
         {
@@ -63,10 +63,10 @@ namespace XCalendar.Forms.Views
             get { return (bool)GetValue(IsDayStateSelectedProperty); }
             set { SetValue(IsDayStateSelectedProperty, value); }
         }
-        public bool IsDayStateOutOfRange
+        public bool IsDayStateInvalid
         {
-            get { return (bool)GetValue(IsDayStateOutOfRangeProperty); }
-            set { SetValue(IsDayStateOutOfRangeProperty, value); }
+            get { return (bool)GetValue(IsDayStateInvalidProperty); }
+            set { SetValue(IsDayStateInvalidProperty, value); }
         }
         public CalendarView CalendarView
         {
@@ -148,30 +148,30 @@ namespace XCalendar.Forms.Views
             get { return (object)GetValue(OtherMonthCommandParameterProperty); }
             set { SetValue(OtherMonthCommandParameterProperty, value); }
         }
-        public Color OutOfRangeTextColor
+        public Color InvalidTextColor
         {
-            get { return (Color)GetValue(OutOfRangeTextColorProperty); }
-            set { SetValue(OutOfRangeTextColorProperty, value); }
+            get { return (Color)GetValue(InvalidTextColorProperty); }
+            set { SetValue(InvalidTextColorProperty, value); }
         }
-        public Color OutOfRangeBackgroundColor
+        public Color InvalidBackgroundColor
         {
-            get { return (Color)GetValue(OutOfRangeBackgroundColorProperty); }
-            set { SetValue(OutOfRangeBackgroundColorProperty, value); }
+            get { return (Color)GetValue(InvalidBackgroundColorProperty); }
+            set { SetValue(InvalidBackgroundColorProperty, value); }
         }
-        public Color OutOfRangeBorderColor
+        public Color InvalidBorderColor
         {
-            get { return (Color)GetValue(OutOfRangeBorderColorProperty); }
-            set { SetValue(OutOfRangeBorderColorProperty, value); }
+            get { return (Color)GetValue(InvalidBorderColorProperty); }
+            set { SetValue(InvalidBorderColorProperty, value); }
         }
-        public ICommand OutOfRangeCommand
+        public ICommand InvalidCommand
         {
-            get { return (ICommand)GetValue(OutOfRangeCommandProperty); }
-            set { SetValue(OutOfRangeCommandProperty, value); }
+            get { return (ICommand)GetValue(InvalidCommandProperty); }
+            set { SetValue(InvalidCommandProperty, value); }
         }
-        public object OutOfRangeCommandParameter
+        public object InvalidCommandParameter
         {
-            get { return (object)GetValue(OutOfRangeCommandParameterProperty); }
-            set { SetValue(OutOfRangeCommandParameterProperty, value); }
+            get { return (object)GetValue(InvalidCommandParameterProperty); }
+            set { SetValue(InvalidCommandParameterProperty, value); }
         }
         public Color SelectedTextColor
         {
@@ -216,13 +216,13 @@ namespace XCalendar.Forms.Views
         public static readonly BindableProperty DayStateProperty = BindableProperty.Create(nameof(IsToday), typeof(DayState), typeof(CalendarDayView), DayState.CurrentMonth, propertyChanged: DayStatePropertyChanged);
         public static readonly BindableProperty IsCurrentMonthProperty = BindableProperty.Create(nameof(IsCurrentMonth), typeof(bool), typeof(CalendarDayView));
         public static readonly BindableProperty IsSelectedProperty = BindableProperty.Create(nameof(IsSelected), typeof(bool), typeof(CalendarDayView));
-        public static readonly BindableProperty IsOutOfRangeProperty = BindableProperty.Create(nameof(IsOutOfRange), typeof(bool), typeof(CalendarDayView));
+        public static readonly BindableProperty IsInvalidProperty = BindableProperty.Create(nameof(IsInvalid), typeof(bool), typeof(CalendarDayView));
         public static readonly BindableProperty IsTodayProperty = BindableProperty.Create(nameof(IsToday), typeof(bool), typeof(CalendarDayView));
         public static readonly BindableProperty IsDayStateCurrentMonthProperty = BindableProperty.Create(nameof(IsDayStateCurrentMonth), typeof(bool), typeof(CalendarDayView), true);
         public static readonly BindableProperty IsDayStateOtherMonthProperty = BindableProperty.Create(nameof(IsDayStateOtherMonth), typeof(bool), typeof(CalendarDayView));
         public static readonly BindableProperty IsDayStateTodayProperty = BindableProperty.Create(nameof(IsDayStateToday), typeof(bool), typeof(CalendarDayView));
         public static readonly BindableProperty IsDayStateSelectedProperty = BindableProperty.Create(nameof(IsDayStateSelected), typeof(bool), typeof(CalendarDayView));
-        public static readonly BindableProperty IsDayStateOutOfRangeProperty = BindableProperty.Create(nameof(IsDayStateOutOfRange), typeof(bool), typeof(CalendarDayView));
+        public static readonly BindableProperty IsDayStateInvalidProperty = BindableProperty.Create(nameof(IsDayStateInvalid), typeof(bool), typeof(CalendarDayView));
         public static readonly BindableProperty CurrentMonthTextColorProperty = BindableProperty.Create(nameof(CurrentMonthTextColor), typeof(Color), typeof(CalendarDayView), Color.Black);
         public static readonly BindableProperty CurrentMonthBackgroundColorProperty = BindableProperty.Create(nameof(CurrentMonthBackgroundColor), typeof(Color), typeof(CalendarDayView), Color.Transparent);
         public static readonly BindableProperty CurrentMonthBorderColorProperty = BindableProperty.Create(nameof(CurrentMonthBorderColor), typeof(Color), typeof(CalendarDayView), BorderColorProperty.DefaultValue);
@@ -238,11 +238,11 @@ namespace XCalendar.Forms.Views
         public static readonly BindableProperty OtherMonthBorderColorProperty = BindableProperty.Create(nameof(OtherMonthBorderColor), typeof(Color), typeof(CalendarDayView), BorderColorProperty.DefaultValue);
         public static readonly BindableProperty OtherMonthCommandProperty = BindableProperty.Create(nameof(OtherMonthCommand), typeof(ICommand), typeof(CalendarDayView));
         public static readonly BindableProperty OtherMonthCommandParameterProperty = BindableProperty.Create(nameof(OtherMonthCommandParameter), typeof(object), typeof(CalendarDayView));
-        public static readonly BindableProperty OutOfRangeTextColorProperty = BindableProperty.Create(nameof(OutOfRangeTextColor), typeof(Color), typeof(CalendarDayView), Color.FromHex("#FFA0A0"));
-        public static readonly BindableProperty OutOfRangeBackgroundColorProperty = BindableProperty.Create(nameof(OutOfRangeBackgroundColor), typeof(Color), typeof(CalendarDayView), Color.Transparent);
-        public static readonly BindableProperty OutOfRangeBorderColorProperty = BindableProperty.Create(nameof(OutOfRangeBorderColor), typeof(Color), typeof(CalendarDayView), BorderColorProperty.DefaultValue);
-        public static readonly BindableProperty OutOfRangeCommandProperty = BindableProperty.Create(nameof(OutOfRangeCommand), typeof(ICommand), typeof(CalendarDayView));
-        public static readonly BindableProperty OutOfRangeCommandParameterProperty = BindableProperty.Create(nameof(OutOfRangeCommandParameter), typeof(object), typeof(CalendarDayView));
+        public static readonly BindableProperty InvalidTextColorProperty = BindableProperty.Create(nameof(InvalidTextColor), typeof(Color), typeof(CalendarDayView), Color.FromHex("#FFA0A0"));
+        public static readonly BindableProperty InvalidBackgroundColorProperty = BindableProperty.Create(nameof(InvalidBackgroundColor), typeof(Color), typeof(CalendarDayView), Color.Transparent);
+        public static readonly BindableProperty InvalidBorderColorProperty = BindableProperty.Create(nameof(InvalidBorderColor), typeof(Color), typeof(CalendarDayView), BorderColorProperty.DefaultValue);
+        public static readonly BindableProperty InvalidCommandProperty = BindableProperty.Create(nameof(InvalidCommand), typeof(ICommand), typeof(CalendarDayView));
+        public static readonly BindableProperty InvalidCommandParameterProperty = BindableProperty.Create(nameof(InvalidCommandParameter), typeof(object), typeof(CalendarDayView));
         public static readonly BindableProperty SelectedTextColorProperty = BindableProperty.Create(nameof(SelectedTextColor), typeof(Color), typeof(CalendarDayView), Color.White);
         public static readonly BindableProperty SelectedBackgroundColorProperty = BindableProperty.Create(nameof(SelectedBackgroundColor), typeof(Color), typeof(CalendarDayView), Color.FromHex("#E00000"));
         public static readonly BindableProperty SelectedBorderColorProperty = BindableProperty.Create(nameof(SelectedBorderColor), typeof(Color), typeof(CalendarDayView), BorderColorProperty.DefaultValue);
@@ -285,7 +285,7 @@ namespace XCalendar.Forms.Views
         public virtual void UpdateProperties()
         {
             IsCurrentMonth = DateTime != null && IsDateTimeCurrentMonth(DateTime.Value);
-            IsOutOfRange = DateTime != null && IsDateTimeOutOfRange(DateTime.Value);
+            IsInvalid = DateTime != null && IsDateTimeInvalid(DateTime.Value);
             IsSelected = DateTime != null && IsDateTimeSelected(DateTime.Value);
             IsToday = DateTime != null && IsDateTimeToday(DateTime.Value);
         }
@@ -293,14 +293,14 @@ namespace XCalendar.Forms.Views
         {
             bool IsOtherMonth = !IsCurrentMonth;
 
-            if (IsOutOfRange)
+            if (IsInvalid)
             {
-                DayState = DayState.OutOfRange;
-                BackgroundColor = OutOfRangeBackgroundColor;
-                BorderColor = OutOfRangeBorderColor;
-                TextColor = OutOfRangeTextColor;
-                Command = OutOfRangeCommand;
-                CommandParameter = OutOfRangeCommandParameter;
+                DayState = DayState.Invalid;
+                BackgroundColor = InvalidBackgroundColor;
+                BorderColor = InvalidBorderColor;
+                TextColor = InvalidTextColor;
+                Command = InvalidCommand;
+                CommandParameter = InvalidCommandParameter;
             }
             else if (IsSelected && IsCurrentMonth)
             {
@@ -347,7 +347,7 @@ namespace XCalendar.Forms.Views
         {
             return DateTime.Month == CalendarView?.NavigatedDate.Month && DateTime.Year == CalendarView?.NavigatedDate.Year;
         }
-        public virtual bool IsDateTimeOutOfRange(DateTime DateTime)
+        public virtual bool IsDateTimeInvalid(DateTime DateTime)
         {
             return DateTime.Date < CalendarView?.NavigationLowerBound.Date || DateTime.Date > CalendarView?.NavigationUpperBound.Date;
         }
@@ -374,7 +374,7 @@ namespace XCalendar.Forms.Views
             Control.IsDayStateOtherMonth = NewDayState == DayState.OtherMonth;
             Control.IsDayStateToday = NewDayState == DayState.Today;
             Control.IsDayStateSelected = NewDayState == DayState.Selected;
-            Control.IsDayStateOutOfRange = NewDayState == DayState.OutOfRange;
+            Control.IsDayStateInvalid = NewDayState == DayState.Invalid;
         }
 
         #region Bindable Properties Methods

--- a/XCalendar.Forms/Views/CalendarView.xaml.cs
+++ b/XCalendar.Forms/Views/CalendarView.xaml.cs
@@ -57,10 +57,10 @@ namespace XCalendar.Forms.Views
         /// The lower bound of the day range.
         /// </summary>
         /// <seealso cref="NavigationLoopMode"/>
-        public DateTime DayRangeMinimumDate
+        public DateTime NavigationLowerBound
         {
-            get { return (DateTime)GetValue(DayRangeMinimumDateProperty); }
-            set { SetValue(DayRangeMinimumDateProperty, value); }
+            get { return (DateTime)GetValue(NavigationLowerBoundProperty); }
+            set { SetValue(NavigationLowerBoundProperty, value); }
         }
         /// <summary>
         /// The upper bound of the day range.
@@ -198,7 +198,7 @@ namespace XCalendar.Forms.Views
             set { SetValue(SelectionActionProperty, value); }
         }
         /// <summary>
-        /// How the calendar handles navigation past the <see cref="DateTime.MinValue"/>, <see cref="DateTime.MaxValue"/>, <see cref="DayRangeMinimumDate"/>, and <see cref="DayRangeMaximumDate"/>.
+        /// How the calendar handles navigation past the <see cref="DateTime.MinValue"/>, <see cref="DateTime.MaxValue"/>, <see cref="NavigationLowerBound"/>, and <see cref="DayRangeMaximumDate"/>.
         /// </summary>
         /// <seealso cref="NavigateCalendar(int)"/>
         public NavigationLoopMode NavigationLoopMode
@@ -325,7 +325,7 @@ namespace XCalendar.Forms.Views
         public static readonly BindableProperty RowsProperty = BindableProperty.Create(nameof(Rows), typeof(int), typeof(CalendarView), 6, defaultBindingMode: BindingMode.TwoWay, propertyChanged: RowsPropertyChanged, validateValue: IsRowsValidValue);
         public static readonly BindableProperty AutoRowsProperty = BindableProperty.Create(nameof(AutoRows), typeof(bool), typeof(CalendarView), true, propertyChanged: AutoRowsPropertyChanged);
         public static readonly BindableProperty AutoRowsIsConsistentProperty = BindableProperty.Create(nameof(AutoRowsIsConsistent), typeof(bool), typeof(CalendarView), true, propertyChanged: AutoRowsIsConsistentPropertyChanged);
-        public static readonly BindableProperty DayRangeMinimumDateProperty = BindableProperty.Create(nameof(DayRangeMinimumDate), typeof(DateTime), typeof(CalendarView), DateTime.MinValue, propertyChanged: DayRangeMinimumDatePropertyChanged);
+        public static readonly BindableProperty NavigationLowerBoundProperty = BindableProperty.Create(nameof(NavigationLowerBound), typeof(DateTime), typeof(CalendarView), DateTime.MinValue, propertyChanged: NavigationLowerBoundPropertyChanged);
         public static readonly BindableProperty DayRangeMaximumDateProperty = BindableProperty.Create(nameof(DayRangeMaximumDate), typeof(DateTime), typeof(CalendarView), DateTime.MaxValue, propertyChanged: DayRangeMaximumDatePropertyChanged);
         public static readonly BindableProperty TodayDateProperty = BindableProperty.Create(nameof(TodayDate), typeof(DateTime), typeof(CalendarView), DateTime.Today, propertyChanged: TodayDatePropertyChanged);
         public static readonly BindableProperty StartOfWeekProperty = BindableProperty.Create(nameof(StartOfWeek), typeof(DayOfWeek), typeof(CalendarView), CultureInfo.CurrentUICulture.DateTimeFormat.FirstDayOfWeek, propertyChanged: StartOfWeekPropertyChanged);
@@ -638,7 +638,7 @@ namespace XCalendar.Forms.Views
         /// <exception cref="NotImplementedException">The current <see cref="PageStartMode"/> is not implemented</exception>
         public virtual void NavigateCalendar(int Amount)
         {
-            NavigatedDate = NavigateDateTime(NavigatedDate, DayRangeMinimumDate, DayRangeMaximumDate, Amount, NavigationLoopMode, NavigationTimeUnit, StartOfWeek);
+            NavigatedDate = NavigateDateTime(NavigatedDate, NavigationLowerBound, DayRangeMaximumDate, Amount, NavigationLoopMode, NavigationTimeUnit, StartOfWeek);
         }
         /// <summary>
         /// Performs navigation on a DateTime.
@@ -804,7 +804,7 @@ namespace XCalendar.Forms.Views
                 Control.OnMonthViewDaysInvalidated();
             }
         }
-        private static void DayRangeMinimumDatePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        private static void NavigationLowerBoundPropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             CalendarView Control = (CalendarView)bindable;
             Control.NavigatedDate = (DateTime)CoerceNavigatedDate(Control, Control.NavigatedDate);
@@ -917,7 +917,7 @@ namespace XCalendar.Forms.Views
             DateTime InitialValue = (DateTime)value;
             CalendarView Control = (CalendarView)bindable;
 
-            DateTime MinimumDate = Control.DayRangeMinimumDate;
+            DateTime MinimumDate = Control.NavigationLowerBound;
             DateTime MaximumDate = Control.DayRangeMaximumDate;
 
             switch (Control.NavigationLoopMode)

--- a/XCalendar.Forms/Views/CalendarView.xaml.cs
+++ b/XCalendar.Forms/Views/CalendarView.xaml.cs
@@ -66,10 +66,10 @@ namespace XCalendar.Forms.Views
         /// The upper bound of the day range.
         /// </summary>
         /// <seealso cref="NavigationLoopMode"/>
-        public DateTime DayRangeMaximumDate
+        public DateTime NavigationUpperBound
         {
-            get { return (DateTime)GetValue(DayRangeMaximumDateProperty); }
-            set { SetValue(DayRangeMaximumDateProperty, value); }
+            get { return (DateTime)GetValue(NavigationUpperBoundProperty); }
+            set { SetValue(NavigationUpperBoundProperty, value); }
         }
         /// <summary>
         /// The day of week that should be considered as the start of the week.
@@ -198,7 +198,7 @@ namespace XCalendar.Forms.Views
             set { SetValue(SelectionActionProperty, value); }
         }
         /// <summary>
-        /// How the calendar handles navigation past the <see cref="DateTime.MinValue"/>, <see cref="DateTime.MaxValue"/>, <see cref="NavigationLowerBound"/>, and <see cref="DayRangeMaximumDate"/>.
+        /// How the calendar handles navigation past the <see cref="DateTime.MinValue"/>, <see cref="DateTime.MaxValue"/>, <see cref="NavigationLowerBound"/>, and <see cref="NavigationUpperBound"/>.
         /// </summary>
         /// <seealso cref="NavigateCalendar(int)"/>
         public NavigationLoopMode NavigationLoopMode
@@ -326,7 +326,7 @@ namespace XCalendar.Forms.Views
         public static readonly BindableProperty AutoRowsProperty = BindableProperty.Create(nameof(AutoRows), typeof(bool), typeof(CalendarView), true, propertyChanged: AutoRowsPropertyChanged);
         public static readonly BindableProperty AutoRowsIsConsistentProperty = BindableProperty.Create(nameof(AutoRowsIsConsistent), typeof(bool), typeof(CalendarView), true, propertyChanged: AutoRowsIsConsistentPropertyChanged);
         public static readonly BindableProperty NavigationLowerBoundProperty = BindableProperty.Create(nameof(NavigationLowerBound), typeof(DateTime), typeof(CalendarView), DateTime.MinValue, propertyChanged: NavigationLowerBoundPropertyChanged);
-        public static readonly BindableProperty DayRangeMaximumDateProperty = BindableProperty.Create(nameof(DayRangeMaximumDate), typeof(DateTime), typeof(CalendarView), DateTime.MaxValue, propertyChanged: DayRangeMaximumDatePropertyChanged);
+        public static readonly BindableProperty NavigationUpperBoundProperty = BindableProperty.Create(nameof(NavigationUpperBound), typeof(DateTime), typeof(CalendarView), DateTime.MaxValue, propertyChanged: NavigationUpperBoundPropertyChanged);
         public static readonly BindableProperty TodayDateProperty = BindableProperty.Create(nameof(TodayDate), typeof(DateTime), typeof(CalendarView), DateTime.Today, propertyChanged: TodayDatePropertyChanged);
         public static readonly BindableProperty StartOfWeekProperty = BindableProperty.Create(nameof(StartOfWeek), typeof(DayOfWeek), typeof(CalendarView), CultureInfo.CurrentUICulture.DateTimeFormat.FirstDayOfWeek, propertyChanged: StartOfWeekPropertyChanged);
         public static readonly BindableProperty SelectionTypeProperty = BindableProperty.Create(nameof(SelectionType), typeof(SelectionType), typeof(CalendarView), SelectionType.None);
@@ -638,7 +638,7 @@ namespace XCalendar.Forms.Views
         /// <exception cref="NotImplementedException">The current <see cref="PageStartMode"/> is not implemented</exception>
         public virtual void NavigateCalendar(int Amount)
         {
-            NavigatedDate = NavigateDateTime(NavigatedDate, NavigationLowerBound, DayRangeMaximumDate, Amount, NavigationLoopMode, NavigationTimeUnit, StartOfWeek);
+            NavigatedDate = NavigateDateTime(NavigatedDate, NavigationLowerBound, NavigationUpperBound, Amount, NavigationLoopMode, NavigationTimeUnit, StartOfWeek);
         }
         /// <summary>
         /// Performs navigation on a DateTime.
@@ -809,7 +809,7 @@ namespace XCalendar.Forms.Views
             CalendarView Control = (CalendarView)bindable;
             Control.NavigatedDate = (DateTime)CoerceNavigatedDate(Control, Control.NavigatedDate);
         }
-        private static void DayRangeMaximumDatePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        private static void NavigationUpperBoundPropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             CalendarView Control = (CalendarView)bindable;
             Control.NavigatedDate = (DateTime)CoerceNavigatedDate(Control, Control.NavigatedDate);
@@ -918,7 +918,7 @@ namespace XCalendar.Forms.Views
             CalendarView Control = (CalendarView)bindable;
 
             DateTime MinimumDate = Control.NavigationLowerBound;
-            DateTime MaximumDate = Control.DayRangeMaximumDate;
+            DateTime MaximumDate = Control.NavigationUpperBound;
 
             switch (Control.NavigationLoopMode)
             {

--- a/XCalendar.Forms/Views/CalendarView.xaml.cs
+++ b/XCalendar.Forms/Views/CalendarView.xaml.cs
@@ -274,11 +274,6 @@ namespace XCalendar.Forms.Views
             get { return (ReadOnlyObservableCollection<DayOfWeek>)GetValue(StartOfWeekDayNamesOrderProperty); }
             protected set { SetValue(StartOfWeekDayNamesOrderProperty, value); }
         }
-        public bool ClampNavigationToDayRange
-        {
-            get { return (bool)GetValue(ClampNavigationToDayRangeProperty); }
-            set { SetValue(ClampNavigationToDayRangeProperty, value); }
-        }
         /// <summary>
         /// The height of the view used to display the navigated date and navigation controls.
         /// </summary>
@@ -364,7 +359,6 @@ namespace XCalendar.Forms.Views
         public static readonly BindableProperty ForwardsNavigationAmountProperty = BindableProperty.Create(nameof(ForwardsNavigationAmount), typeof(int), typeof(CalendarView), 1);
         public static readonly BindableProperty BackwardsNavigationAmountProperty = BindableProperty.Create(nameof(BackwardsNavigationAmount), typeof(int), typeof(CalendarView), -1);
         public static readonly BindableProperty PageStartModeProperty = BindableProperty.Create(nameof(PageStartMode), typeof(PageStartMode), typeof(CalendarView), PageStartMode.FirstDayOfMonth, propertyChanged: PageStartModePropertyChanged);
-        public static readonly BindableProperty ClampNavigationToDayRangeProperty = BindableProperty.Create(nameof(ClampNavigationToDayRange), typeof(bool), typeof(CalendarView), true, propertyChanged: ClampNavigationToDayRangePropertyChanged);
         public static readonly BindableProperty DayResolverProperty = BindableProperty.Create(nameof(DayResolver), typeof(ICalendarDayResolver), typeof(CalendarView), new DefaultCalendarDayResolver(), propertyChanged: DayResolverPropertyChanged);
         #endregion
 
@@ -644,10 +638,7 @@ namespace XCalendar.Forms.Views
         /// <exception cref="NotImplementedException">The current <see cref="PageStartMode"/> is not implemented</exception>
         public virtual void NavigateCalendar(int Amount)
         {
-            DateTime MinimumDate = ClampNavigationToDayRange ? DayRangeMinimumDate : DateTime.MinValue;
-            DateTime MaximumDate = ClampNavigationToDayRange ? DayRangeMaximumDate : DateTime.MaxValue;
-
-            NavigatedDate = NavigateDateTime(NavigatedDate, MinimumDate, MaximumDate, Amount, NavigationLoopMode, NavigationTimeUnit, StartOfWeek);
+            NavigatedDate = NavigateDateTime(NavigatedDate, DayRangeMinimumDate, DayRangeMaximumDate, Amount, NavigationLoopMode, NavigationTimeUnit, StartOfWeek);
         }
         /// <summary>
         /// Performs navigation on a DateTime.
@@ -788,12 +779,6 @@ namespace XCalendar.Forms.Views
                 Control.Rows = CoercedRows;
             }
         }
-        private static void ClampNavigationToDayRangePropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            CalendarView Control = (CalendarView)bindable;
-            Control.NavigatedDate = (DateTime)CoerceNavigatedDate(Control, Control.NavigatedDate);
-            //Control.CoerceValue(NavigatedDateProperty);
-        }
         private static void TodayDatePropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             CalendarView Control = (CalendarView)bindable;
@@ -932,8 +917,8 @@ namespace XCalendar.Forms.Views
             DateTime InitialValue = (DateTime)value;
             CalendarView Control = (CalendarView)bindable;
 
-            DateTime MinimumDate = Control.ClampNavigationToDayRange ? Control.DayRangeMinimumDate : DateTime.MinValue;
-            DateTime MaximumDate = Control.ClampNavigationToDayRange ? Control.DayRangeMaximumDate : DateTime.MaxValue;
+            DateTime MinimumDate = Control.DayRangeMinimumDate;
+            DateTime MaximumDate = Control.DayRangeMaximumDate;
 
             switch (Control.NavigationLoopMode)
             {

--- a/XCalendar.Maui/Enums/DayState.cs
+++ b/XCalendar.Maui/Enums/DayState.cs
@@ -6,6 +6,6 @@
         OtherMonth,
         Today,
         Selected,
-        OutOfRange
+        Invalid
     }
 }

--- a/XCalendar.Maui/Views/CalendarDayView.xaml.cs
+++ b/XCalendar.Maui/Views/CalendarDayView.xaml.cs
@@ -436,7 +436,7 @@ namespace XCalendar.Maui.Views
         }
         public virtual bool IsDateTimeOutOfRange(DateTime DateTime)
         {
-            return DateTime.Date < CalendarView?.DayRangeMinimumDate.Date || DateTime.Date > CalendarView?.DayRangeMaximumDate.Date;
+            return DateTime.Date < CalendarView?.NavigationLowerBound.Date || DateTime.Date > CalendarView?.DayRangeMaximumDate.Date;
         }
         public virtual bool IsDateTimeToday(DateTime DateTime)
         {

--- a/XCalendar.Maui/Views/CalendarDayView.xaml.cs
+++ b/XCalendar.Maui/Views/CalendarDayView.xaml.cs
@@ -436,7 +436,7 @@ namespace XCalendar.Maui.Views
         }
         public virtual bool IsDateTimeOutOfRange(DateTime DateTime)
         {
-            return DateTime.Date < CalendarView?.NavigationLowerBound.Date || DateTime.Date > CalendarView?.DayRangeMaximumDate.Date;
+            return DateTime.Date < CalendarView?.NavigationLowerBound.Date || DateTime.Date > CalendarView?.NavigationUpperBound.Date;
         }
         public virtual bool IsDateTimeToday(DateTime DateTime)
         {

--- a/XCalendar.Maui/Views/CalendarDayView.xaml.cs
+++ b/XCalendar.Maui/Views/CalendarDayView.xaml.cs
@@ -28,10 +28,10 @@ namespace XCalendar.Maui.Views
             get { return (bool)GetValue(IsSelectedProperty); }
             set { SetValue(IsSelectedProperty, value); }
         }
-        public bool IsOutOfRange
+        public bool IsInvalid
         {
-            get { return (bool)GetValue(IsOutOfRangeProperty); }
-            set { SetValue(IsOutOfRangeProperty, value); }
+            get { return (bool)GetValue(IsInvalidProperty); }
+            set { SetValue(IsInvalidProperty, value); }
         }
         public bool IsToday
         {
@@ -58,10 +58,10 @@ namespace XCalendar.Maui.Views
             get { return (bool)GetValue(IsDayStateSelectedProperty); }
             set { SetValue(IsDayStateSelectedProperty, value); }
         }
-        public bool IsDayStateOutOfRange
+        public bool IsDayStateInvalid
         {
-            get { return (bool)GetValue(IsDayStateOutOfRangeProperty); }
-            set { SetValue(IsDayStateOutOfRangeProperty, value); }
+            get { return (bool)GetValue(IsDayStateInvalidProperty); }
+            set { SetValue(IsDayStateInvalidProperty, value); }
         }
         public CalendarView CalendarView
         {
@@ -143,30 +143,30 @@ namespace XCalendar.Maui.Views
             get { return (object)GetValue(OtherMonthCommandParameterProperty); }
             set { SetValue(OtherMonthCommandParameterProperty, value); }
         }
-        public Color OutOfRangeTextColor
+        public Color InvalidTextColor
         {
-            get { return (Color)GetValue(OutOfRangeTextColorProperty); }
-            set { SetValue(OutOfRangeTextColorProperty, value); }
+            get { return (Color)GetValue(InvalidTextColorProperty); }
+            set { SetValue(InvalidTextColorProperty, value); }
         }
-        public Color OutOfRangeBackgroundColor
+        public Color InvalidBackgroundColor
         {
-            get { return (Color)GetValue(OutOfRangeBackgroundColorProperty); }
-            set { SetValue(OutOfRangeBackgroundColorProperty, value); }
+            get { return (Color)GetValue(InvalidBackgroundColorProperty); }
+            set { SetValue(InvalidBackgroundColorProperty, value); }
         }
-        public Color OutOfRangeBorderColor
+        public Color InvalidBorderColor
         {
-            get { return (Color)GetValue(OutOfRangeBorderColorProperty); }
-            set { SetValue(OutOfRangeBorderColorProperty, value); }
+            get { return (Color)GetValue(InvalidBorderColorProperty); }
+            set { SetValue(InvalidBorderColorProperty, value); }
         }
-        public ICommand OutOfRangeCommand
+        public ICommand InvalidCommand
         {
-            get { return (ICommand)GetValue(OutOfRangeCommandProperty); }
-            set { SetValue(OutOfRangeCommandProperty, value); }
+            get { return (ICommand)GetValue(InvalidCommandProperty); }
+            set { SetValue(InvalidCommandProperty, value); }
         }
-        public object OutOfRangeCommandParameter
+        public object InvalidCommandParameter
         {
-            get { return (object)GetValue(OutOfRangeCommandParameterProperty); }
-            set { SetValue(OutOfRangeCommandParameterProperty, value); }
+            get { return (object)GetValue(InvalidCommandParameterProperty); }
+            set { SetValue(InvalidCommandParameterProperty, value); }
         }
         public Color SelectedTextColor
         {
@@ -286,13 +286,13 @@ namespace XCalendar.Maui.Views
         public static readonly BindableProperty DayStateProperty = BindableProperty.Create(nameof(IsToday), typeof(DayState), typeof(CalendarDayView), DayState.CurrentMonth, propertyChanged: DayStatePropertyChanged);
         public static readonly BindableProperty IsCurrentMonthProperty = BindableProperty.Create(nameof(IsCurrentMonth), typeof(bool), typeof(CalendarDayView));
         public static readonly BindableProperty IsSelectedProperty = BindableProperty.Create(nameof(IsSelected), typeof(bool), typeof(CalendarDayView));
-        public static readonly BindableProperty IsOutOfRangeProperty = BindableProperty.Create(nameof(IsOutOfRange), typeof(bool), typeof(CalendarDayView));
+        public static readonly BindableProperty IsInvalidProperty = BindableProperty.Create(nameof(IsInvalid), typeof(bool), typeof(CalendarDayView));
         public static readonly BindableProperty IsTodayProperty = BindableProperty.Create(nameof(IsToday), typeof(bool), typeof(CalendarDayView));
         public static readonly BindableProperty IsDayStateCurrentMonthProperty = BindableProperty.Create(nameof(IsDayStateCurrentMonth), typeof(bool), typeof(CalendarDayView), true);
         public static readonly BindableProperty IsDayStateOtherMonthProperty = BindableProperty.Create(nameof(IsDayStateOtherMonth), typeof(bool), typeof(CalendarDayView));
         public static readonly BindableProperty IsDayStateTodayProperty = BindableProperty.Create(nameof(IsDayStateToday), typeof(bool), typeof(CalendarDayView));
         public static readonly BindableProperty IsDayStateSelectedProperty = BindableProperty.Create(nameof(IsDayStateSelected), typeof(bool), typeof(CalendarDayView));
-        public static readonly BindableProperty IsDayStateOutOfRangeProperty = BindableProperty.Create(nameof(IsDayStateOutOfRange), typeof(bool), typeof(CalendarDayView));
+        public static readonly BindableProperty IsDayStateInvalidProperty = BindableProperty.Create(nameof(IsDayStateInvalid), typeof(bool), typeof(CalendarDayView));
         public static readonly BindableProperty CurrentMonthTextColorProperty = BindableProperty.Create(nameof(CurrentMonthTextColor), typeof(Color), typeof(CalendarDayView), Colors.Black);
         public static readonly BindableProperty CurrentMonthBackgroundColorProperty = BindableProperty.Create(nameof(CurrentMonthBackgroundColor), typeof(Color), typeof(CalendarDayView), Colors.Transparent);
         public static readonly BindableProperty CurrentMonthBorderColorProperty = BindableProperty.Create(nameof(CurrentMonthBorderColor), typeof(Color), typeof(CalendarDayView), Colors.Transparent);
@@ -308,11 +308,11 @@ namespace XCalendar.Maui.Views
         public static readonly BindableProperty OtherMonthBorderColorProperty = BindableProperty.Create(nameof(OtherMonthBorderColor), typeof(Color), typeof(CalendarDayView), Colors.Transparent);
         public static readonly BindableProperty OtherMonthCommandProperty = BindableProperty.Create(nameof(OtherMonthCommand), typeof(ICommand), typeof(CalendarDayView));
         public static readonly BindableProperty OtherMonthCommandParameterProperty = BindableProperty.Create(nameof(OtherMonthCommandParameter), typeof(object), typeof(CalendarDayView));
-        public static readonly BindableProperty OutOfRangeTextColorProperty = BindableProperty.Create(nameof(OutOfRangeTextColor), typeof(Color), typeof(CalendarDayView), Color.FromArgb("#FFFFA0A0"));
-        public static readonly BindableProperty OutOfRangeBackgroundColorProperty = BindableProperty.Create(nameof(OutOfRangeBackgroundColor), typeof(Color), typeof(CalendarDayView), Colors.Transparent);
-        public static readonly BindableProperty OutOfRangeBorderColorProperty = BindableProperty.Create(nameof(OutOfRangeBorderColor), typeof(Color), typeof(CalendarDayView), Colors.Transparent);
-        public static readonly BindableProperty OutOfRangeCommandProperty = BindableProperty.Create(nameof(OutOfRangeCommand), typeof(ICommand), typeof(CalendarDayView));
-        public static readonly BindableProperty OutOfRangeCommandParameterProperty = BindableProperty.Create(nameof(OutOfRangeCommandParameter), typeof(object), typeof(CalendarDayView));
+        public static readonly BindableProperty InvalidTextColorProperty = BindableProperty.Create(nameof(InvalidTextColor), typeof(Color), typeof(CalendarDayView), Color.FromArgb("#FFFFA0A0"));
+        public static readonly BindableProperty InvalidBackgroundColorProperty = BindableProperty.Create(nameof(InvalidBackgroundColor), typeof(Color), typeof(CalendarDayView), Colors.Transparent);
+        public static readonly BindableProperty InvalidBorderColorProperty = BindableProperty.Create(nameof(InvalidBorderColor), typeof(Color), typeof(CalendarDayView), Colors.Transparent);
+        public static readonly BindableProperty InvalidCommandProperty = BindableProperty.Create(nameof(InvalidCommand), typeof(ICommand), typeof(CalendarDayView));
+        public static readonly BindableProperty InvalidCommandParameterProperty = BindableProperty.Create(nameof(InvalidCommandParameter), typeof(object), typeof(CalendarDayView));
         public static readonly BindableProperty SelectedTextColorProperty = BindableProperty.Create(nameof(SelectedTextColor), typeof(Color), typeof(CalendarDayView), Colors.White);
         public static readonly BindableProperty SelectedBackgroundColorProperty = BindableProperty.Create(nameof(SelectedBackgroundColor), typeof(Color), typeof(CalendarDayView), Color.FromArgb("#FFE00000"));
         public static readonly BindableProperty SelectedBorderColorProperty = BindableProperty.Create(nameof(SelectedBorderColor), typeof(Color), typeof(CalendarDayView), Colors.Transparent);
@@ -372,7 +372,7 @@ namespace XCalendar.Maui.Views
         public virtual void UpdateProperties()
         {
             IsCurrentMonth = DateTime != null && IsDateTimeCurrentMonth(DateTime.Value);
-            IsOutOfRange = DateTime != null && IsDateTimeOutOfRange(DateTime.Value);
+            IsInvalid = DateTime != null && IsDateTimeInvalid(DateTime.Value);
             IsSelected = DateTime != null && IsDateTimeSelected(DateTime.Value);
             IsToday = DateTime != null && IsDateTimeToday(DateTime.Value);
         }
@@ -380,14 +380,14 @@ namespace XCalendar.Maui.Views
         {
             bool IsOtherMonth = !IsCurrentMonth;
 
-            if (IsOutOfRange)
+            if (IsInvalid)
             {
-                DayState = DayState.OutOfRange;
-                BackgroundColor = OutOfRangeBackgroundColor;
-                //BorderColor = OutOfRangeBorderColor;
-                TextColor = OutOfRangeTextColor;
-                Command = OutOfRangeCommand;
-                CommandParameter = OutOfRangeCommandParameter;
+                DayState = DayState.Invalid;
+                BackgroundColor = InvalidBackgroundColor;
+                //BorderColor = InvalidBorderColor;
+                TextColor = InvalidTextColor;
+                Command = InvalidCommand;
+                CommandParameter = InvalidCommandParameter;
             }
             else if (IsSelected && IsCurrentMonth)
             {
@@ -434,7 +434,7 @@ namespace XCalendar.Maui.Views
         {
             return DateTime.Month == CalendarView?.NavigatedDate.Month && DateTime.Year == CalendarView?.NavigatedDate.Year;
         }
-        public virtual bool IsDateTimeOutOfRange(DateTime DateTime)
+        public virtual bool IsDateTimeInvalid(DateTime DateTime)
         {
             return DateTime.Date < CalendarView?.NavigationLowerBound.Date || DateTime.Date > CalendarView?.NavigationUpperBound.Date;
         }
@@ -461,7 +461,7 @@ namespace XCalendar.Maui.Views
             Control.IsDayStateOtherMonth = NewDayState == DayState.OtherMonth;
             Control.IsDayStateToday = NewDayState == DayState.Today;
             Control.IsDayStateSelected = NewDayState == DayState.Selected;
-            Control.IsDayStateOutOfRange = NewDayState == DayState.OutOfRange;
+            Control.IsDayStateInvalid = NewDayState == DayState.Invalid;
         }
 
         #region Bindable Properties Methods

--- a/XCalendar.Maui/Views/CalendarView.xaml.cs
+++ b/XCalendar.Maui/Views/CalendarView.xaml.cs
@@ -55,10 +55,10 @@ namespace XCalendar.Maui.Views
         /// The lower bound of the day range.
         /// </summary>
         /// <seealso cref="NavigationLoopMode"/>
-        public DateTime DayRangeMinimumDate
+        public DateTime NavigationLowerBound
         {
-            get { return (DateTime)GetValue(DayRangeMinimumDateProperty); }
-            set { SetValue(DayRangeMinimumDateProperty, value); }
+            get { return (DateTime)GetValue(NavigationLowerBoundProperty); }
+            set { SetValue(NavigationLowerBoundProperty, value); }
         }
         /// <summary>
         /// The upper bound of the day range.
@@ -196,7 +196,7 @@ namespace XCalendar.Maui.Views
             set { SetValue(SelectionActionProperty, value); }
         }
         /// <summary>
-        /// How the calendar handles navigation past the <see cref="DateTime.MinValue"/>, <see cref="DateTime.MaxValue"/>, <see cref="DayRangeMinimumDate"/>, and <see cref="DayRangeMaximumDate"/>.
+        /// How the calendar handles navigation past the <see cref="DateTime.MinValue"/>, <see cref="DateTime.MaxValue"/>, <see cref="NavigationLowerBound"/>, and <see cref="DayRangeMaximumDate"/>.
         /// </summary>
         /// <seealso cref="NavigateCalendar(int)"/>
         public NavigationLoopMode NavigationLoopMode
@@ -323,7 +323,7 @@ namespace XCalendar.Maui.Views
         public static readonly BindableProperty RowsProperty = BindableProperty.Create(nameof(Rows), typeof(int), typeof(CalendarView), 6, defaultBindingMode: BindingMode.TwoWay, propertyChanged: RowsPropertyChanged, validateValue: IsRowsValidValue);
         public static readonly BindableProperty AutoRowsProperty = BindableProperty.Create(nameof(AutoRows), typeof(bool), typeof(CalendarView), true, propertyChanged: AutoRowsPropertyChanged);
         public static readonly BindableProperty AutoRowsIsConsistentProperty = BindableProperty.Create(nameof(AutoRowsIsConsistent), typeof(bool), typeof(CalendarView), true, propertyChanged: AutoRowsIsConsistentPropertyChanged);
-        public static readonly BindableProperty DayRangeMinimumDateProperty = BindableProperty.Create(nameof(DayRangeMinimumDate), typeof(DateTime), typeof(CalendarView), DateTime.MinValue, propertyChanged: DayRangeMinimumDatePropertyChanged);
+        public static readonly BindableProperty NavigationLowerBoundProperty = BindableProperty.Create(nameof(NavigationLowerBound), typeof(DateTime), typeof(CalendarView), DateTime.MinValue, propertyChanged: NavigationLowerBoundPropertyChanged);
         public static readonly BindableProperty DayRangeMaximumDateProperty = BindableProperty.Create(nameof(DayRangeMaximumDate), typeof(DateTime), typeof(CalendarView), DateTime.MaxValue, propertyChanged: DayRangeMaximumDatePropertyChanged);
         public static readonly BindableProperty TodayDateProperty = BindableProperty.Create(nameof(TodayDate), typeof(DateTime), typeof(CalendarView), DateTime.Today, propertyChanged: TodayDatePropertyChanged);
         public static readonly BindableProperty StartOfWeekProperty = BindableProperty.Create(nameof(StartOfWeek), typeof(DayOfWeek), typeof(CalendarView), CultureInfo.CurrentUICulture.DateTimeFormat.FirstDayOfWeek, propertyChanged: StartOfWeekPropertyChanged);
@@ -636,7 +636,7 @@ namespace XCalendar.Maui.Views
         /// <exception cref="NotImplementedException">The current <see cref="PageStartMode"/> is not implemented</exception>
         public virtual void NavigateCalendar(int Amount)
         {
-            NavigatedDate = NavigateDateTime(NavigatedDate, DayRangeMinimumDate, DayRangeMaximumDate, Amount, NavigationLoopMode, NavigationTimeUnit, StartOfWeek);
+            NavigatedDate = NavigateDateTime(NavigatedDate, NavigationLowerBound, DayRangeMaximumDate, Amount, NavigationLoopMode, NavigationTimeUnit, StartOfWeek);
         }
         /// <summary>
         /// Performs navigation on a DateTime.
@@ -802,7 +802,7 @@ namespace XCalendar.Maui.Views
                 Control.OnMonthViewDaysInvalidated();
             }
         }
-        private static void DayRangeMinimumDatePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        private static void NavigationLowerBoundPropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             CalendarView Control = (CalendarView)bindable;
             Control.NavigatedDate = (DateTime)CoerceNavigatedDate(Control, Control.NavigatedDate);
@@ -915,7 +915,7 @@ namespace XCalendar.Maui.Views
             DateTime InitialValue = (DateTime)value;
             CalendarView Control = (CalendarView)bindable;
 
-            DateTime MinimumDate = Control.DayRangeMinimumDate;
+            DateTime MinimumDate = Control.NavigationLowerBound;
             DateTime MaximumDate = Control.DayRangeMaximumDate;
 
             switch (Control.NavigationLoopMode)

--- a/XCalendar.Maui/Views/CalendarView.xaml.cs
+++ b/XCalendar.Maui/Views/CalendarView.xaml.cs
@@ -64,10 +64,10 @@ namespace XCalendar.Maui.Views
         /// The upper bound of the day range.
         /// </summary>
         /// <seealso cref="NavigationLoopMode"/>
-        public DateTime DayRangeMaximumDate
+        public DateTime NavigationUpperBound
         {
-            get { return (DateTime)GetValue(DayRangeMaximumDateProperty); }
-            set { SetValue(DayRangeMaximumDateProperty, value); }
+            get { return (DateTime)GetValue(NavigationUpperBoundProperty); }
+            set { SetValue(NavigationUpperBoundProperty, value); }
         }
         /// <summary>
         /// The day of week that should be considered as the start of the week.
@@ -196,7 +196,7 @@ namespace XCalendar.Maui.Views
             set { SetValue(SelectionActionProperty, value); }
         }
         /// <summary>
-        /// How the calendar handles navigation past the <see cref="DateTime.MinValue"/>, <see cref="DateTime.MaxValue"/>, <see cref="NavigationLowerBound"/>, and <see cref="DayRangeMaximumDate"/>.
+        /// How the calendar handles navigation past the <see cref="DateTime.MinValue"/>, <see cref="DateTime.MaxValue"/>, <see cref="NavigationLowerBound"/>, and <see cref="NavigationUpperBound"/>.
         /// </summary>
         /// <seealso cref="NavigateCalendar(int)"/>
         public NavigationLoopMode NavigationLoopMode
@@ -324,7 +324,7 @@ namespace XCalendar.Maui.Views
         public static readonly BindableProperty AutoRowsProperty = BindableProperty.Create(nameof(AutoRows), typeof(bool), typeof(CalendarView), true, propertyChanged: AutoRowsPropertyChanged);
         public static readonly BindableProperty AutoRowsIsConsistentProperty = BindableProperty.Create(nameof(AutoRowsIsConsistent), typeof(bool), typeof(CalendarView), true, propertyChanged: AutoRowsIsConsistentPropertyChanged);
         public static readonly BindableProperty NavigationLowerBoundProperty = BindableProperty.Create(nameof(NavigationLowerBound), typeof(DateTime), typeof(CalendarView), DateTime.MinValue, propertyChanged: NavigationLowerBoundPropertyChanged);
-        public static readonly BindableProperty DayRangeMaximumDateProperty = BindableProperty.Create(nameof(DayRangeMaximumDate), typeof(DateTime), typeof(CalendarView), DateTime.MaxValue, propertyChanged: DayRangeMaximumDatePropertyChanged);
+        public static readonly BindableProperty NavigationUpperBoundProperty = BindableProperty.Create(nameof(NavigationUpperBound), typeof(DateTime), typeof(CalendarView), DateTime.MaxValue, propertyChanged: NavigationUpperBoundPropertyChanged);
         public static readonly BindableProperty TodayDateProperty = BindableProperty.Create(nameof(TodayDate), typeof(DateTime), typeof(CalendarView), DateTime.Today, propertyChanged: TodayDatePropertyChanged);
         public static readonly BindableProperty StartOfWeekProperty = BindableProperty.Create(nameof(StartOfWeek), typeof(DayOfWeek), typeof(CalendarView), CultureInfo.CurrentUICulture.DateTimeFormat.FirstDayOfWeek, propertyChanged: StartOfWeekPropertyChanged);
         public static readonly BindableProperty SelectionTypeProperty = BindableProperty.Create(nameof(SelectionType), typeof(SelectionType), typeof(CalendarView), SelectionType.None);
@@ -636,7 +636,7 @@ namespace XCalendar.Maui.Views
         /// <exception cref="NotImplementedException">The current <see cref="PageStartMode"/> is not implemented</exception>
         public virtual void NavigateCalendar(int Amount)
         {
-            NavigatedDate = NavigateDateTime(NavigatedDate, NavigationLowerBound, DayRangeMaximumDate, Amount, NavigationLoopMode, NavigationTimeUnit, StartOfWeek);
+            NavigatedDate = NavigateDateTime(NavigatedDate, NavigationLowerBound, NavigationUpperBound, Amount, NavigationLoopMode, NavigationTimeUnit, StartOfWeek);
         }
         /// <summary>
         /// Performs navigation on a DateTime.
@@ -807,7 +807,7 @@ namespace XCalendar.Maui.Views
             CalendarView Control = (CalendarView)bindable;
             Control.NavigatedDate = (DateTime)CoerceNavigatedDate(Control, Control.NavigatedDate);
         }
-        private static void DayRangeMaximumDatePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        private static void NavigationUpperBoundPropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             CalendarView Control = (CalendarView)bindable;
             Control.NavigatedDate = (DateTime)CoerceNavigatedDate(Control, Control.NavigatedDate);
@@ -916,7 +916,7 @@ namespace XCalendar.Maui.Views
             CalendarView Control = (CalendarView)bindable;
 
             DateTime MinimumDate = Control.NavigationLowerBound;
-            DateTime MaximumDate = Control.DayRangeMaximumDate;
+            DateTime MaximumDate = Control.NavigationUpperBound;
 
             switch (Control.NavigationLoopMode)
             {

--- a/XCalendar.Maui/Views/CalendarView.xaml.cs
+++ b/XCalendar.Maui/Views/CalendarView.xaml.cs
@@ -272,11 +272,6 @@ namespace XCalendar.Maui.Views
             get { return (ReadOnlyObservableCollection<DayOfWeek>)GetValue(StartOfWeekDayNamesOrderProperty); }
             protected set { SetValue(StartOfWeekDayNamesOrderProperty, value); }
         }
-        public bool ClampNavigationToDayRange
-        {
-            get { return (bool)GetValue(ClampNavigationToDayRangeProperty); }
-            set { SetValue(ClampNavigationToDayRangeProperty, value); }
-        }
         /// <summary>
         /// The height of the view used to display the navigated date and navigation controls.
         /// </summary>
@@ -362,7 +357,6 @@ namespace XCalendar.Maui.Views
         public static readonly BindableProperty ForwardsNavigationAmountProperty = BindableProperty.Create(nameof(ForwardsNavigationAmount), typeof(int), typeof(CalendarView), 1);
         public static readonly BindableProperty BackwardsNavigationAmountProperty = BindableProperty.Create(nameof(BackwardsNavigationAmount), typeof(int), typeof(CalendarView), -1);
         public static readonly BindableProperty PageStartModeProperty = BindableProperty.Create(nameof(PageStartMode), typeof(PageStartMode), typeof(CalendarView), PageStartMode.FirstDayOfMonth, propertyChanged: PageStartModePropertyChanged);
-        public static readonly BindableProperty ClampNavigationToDayRangeProperty = BindableProperty.Create(nameof(ClampNavigationToDayRange), typeof(bool), typeof(CalendarView), true, propertyChanged: ClampNavigationToDayRangePropertyChanged);
         public static readonly BindableProperty DayResolverProperty = BindableProperty.Create(nameof(DayResolver), typeof(ICalendarDayResolver), typeof(CalendarView), new DefaultCalendarDayResolver(), propertyChanged: DayResolverPropertyChanged);
         #endregion
 
@@ -642,10 +636,7 @@ namespace XCalendar.Maui.Views
         /// <exception cref="NotImplementedException">The current <see cref="PageStartMode"/> is not implemented</exception>
         public virtual void NavigateCalendar(int Amount)
         {
-            DateTime MinimumDate = ClampNavigationToDayRange ? DayRangeMinimumDate : DateTime.MinValue;
-            DateTime MaximumDate = ClampNavigationToDayRange ? DayRangeMaximumDate : DateTime.MaxValue;
-
-            NavigatedDate = NavigateDateTime(NavigatedDate, MinimumDate, MaximumDate, Amount, NavigationLoopMode, NavigationTimeUnit, StartOfWeek);
+            NavigatedDate = NavigateDateTime(NavigatedDate, DayRangeMinimumDate, DayRangeMaximumDate, Amount, NavigationLoopMode, NavigationTimeUnit, StartOfWeek);
         }
         /// <summary>
         /// Performs navigation on a DateTime.
@@ -786,12 +777,6 @@ namespace XCalendar.Maui.Views
                 Control.Rows = CoercedRows;
             }
         }
-        private static void ClampNavigationToDayRangePropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            CalendarView Control = (CalendarView)bindable;
-            Control.NavigatedDate = (DateTime)CoerceNavigatedDate(Control, Control.NavigatedDate);
-            //Control.CoerceValue(NavigatedDateProperty);
-        }
         private static void TodayDatePropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             CalendarView Control = (CalendarView)bindable;
@@ -930,8 +915,8 @@ namespace XCalendar.Maui.Views
             DateTime InitialValue = (DateTime)value;
             CalendarView Control = (CalendarView)bindable;
 
-            DateTime MinimumDate = Control.ClampNavigationToDayRange ? Control.DayRangeMinimumDate : DateTime.MinValue;
-            DateTime MaximumDate = Control.ClampNavigationToDayRange ? Control.DayRangeMaximumDate : DateTime.MaxValue;
+            DateTime MinimumDate = Control.DayRangeMinimumDate;
+            DateTime MaximumDate = Control.DayRangeMaximumDate;
 
             switch (Control.NavigationLoopMode)
             {

--- a/XCalendarFormsSample/XCalendarFormsSample/Popups/DatePickerDialogPopup.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Popups/DatePickerDialogPopup.xaml
@@ -72,7 +72,7 @@
                         FontSize="12"
                         HeightRequest="41"
                         OtherMonthTextColor="Transparent"
-                        OutOfRangeBackgroundColor="Transparent"
+                        InvalidBackgroundColor="Transparent"
                         SelectedBackgroundColor="{StaticResource PrimaryPickerColor}"
                         SelectedTextColor="White"
                         TodayBackgroundColor="Transparent"

--- a/XCalendarFormsSample/XCalendarFormsSample/ViewModels/PlaygroundViewModel.cs
+++ b/XCalendarFormsSample/XCalendarFormsSample/ViewModels/PlaygroundViewModel.cs
@@ -31,7 +31,7 @@ namespace XCalendarFormsSample.ViewModels
             DayOfWeek.Sunday
         };
         public DateTime NavigatedDate { get; set; } = DateTime.Today;
-        public DateTime DayRangeMinimumDate { get; set; } = DateTime.Today.AddYears(-2);
+        public DateTime NavigationLowerBound { get; set; } = DateTime.Today.AddYears(-2);
         public DateTime DayRangeMaximumDate { get; set; } = DateTime.Today.AddYears(2);
         public DayOfWeek StartOfWeek { get; set; } = DayOfWeek.Monday;
         public ObservableRangeCollection<DayOfWeek> CustomDayNamesOrder { get; } = new ObservableRangeCollection<DayOfWeek>()

--- a/XCalendarFormsSample/XCalendarFormsSample/ViewModels/PlaygroundViewModel.cs
+++ b/XCalendarFormsSample/XCalendarFormsSample/ViewModels/PlaygroundViewModel.cs
@@ -32,7 +32,7 @@ namespace XCalendarFormsSample.ViewModels
         };
         public DateTime NavigatedDate { get; set; } = DateTime.Today;
         public DateTime NavigationLowerBound { get; set; } = DateTime.Today.AddYears(-2);
-        public DateTime DayRangeMaximumDate { get; set; } = DateTime.Today.AddYears(2);
+        public DateTime NavigationUpperBound { get; set; } = DateTime.Today.AddYears(2);
         public DayOfWeek StartOfWeek { get; set; } = DayOfWeek.Monday;
         public ObservableRangeCollection<DayOfWeek> CustomDayNamesOrder { get; } = new ObservableRangeCollection<DayOfWeek>()
         {

--- a/XCalendarFormsSample/XCalendarFormsSample/ViewModels/PlaygroundViewModel.cs
+++ b/XCalendarFormsSample/XCalendarFormsSample/ViewModels/PlaygroundViewModel.cs
@@ -58,7 +58,6 @@ namespace XCalendarFormsSample.ViewModels
         public double DayNamesHeightRequest { get; set; } = 25;
         public bool UseCustomDayNamesOrder { get; set; } = false;
         public DateTime TodayDate { get; set; } = DateTime.Today;
-        public bool ClampNavigationToDayRange { get; set; } = true;
         public double NavigationHeightRequest { get; set; } = 40;
         public int ForwardsNavigationAmount { get; set; } = 1;
         public int BackwardsNavigationAmount { get; set; } = -1;

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/EventCalendarExamplePage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/EventCalendarExamplePage.xaml
@@ -59,7 +59,7 @@
                                 CalendarView="{Binding ., Source={x:Reference MainCalendarView}}"
                                 CurrentMonthTextColor="{StaticResource CalendarBackgroundTextColor}"
                                 DateTime="{Binding DateTime}"
-                                OutOfRangeTextColor="{StaticResource CalendarTertiaryColor}"
+                                InvalidTextColor="{StaticResource CalendarTertiaryColor}"
                                 SelectedTextColor="{StaticResource CalendarPrimaryTextColor}"
                                 TodayBorderColor="{StaticResource CalendarPrimaryColor}"
                                 TodayTextColor="{StaticResource CalendarBackgroundTextColor}">
@@ -103,7 +103,7 @@
                                                         <Binding Path="IsCurrentMonth" Source="{RelativeSource TemplatedParent}"/>
                                                         <Binding
                                                             Converter="{StaticResource InvertedBoolConverter}"
-                                                            Path="IsOutOfRange"
+                                                            Path="IsInvalid"
                                                             Source="{RelativeSource TemplatedParent}"/>
                                                     </MultiBinding>
                                                 </StackLayout.IsVisible>

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/PlaygroundPage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/PlaygroundPage.xaml
@@ -166,7 +166,7 @@
                                 Grid.Column="0"
                                 FontSize="{StaticResource SmallFontSize}"
                                 HorizontalTextAlignment="Center"
-                                Text="DayRangeMinDate"
+                                Text="NavigationLowerBound"
                                 VerticalTextAlignment="Center"/>
                             <Editor
                                 Grid.Column="1"
@@ -191,7 +191,7 @@
                                 Grid.Column="0"
                                 FontSize="{StaticResource SmallFontSize}"
                                 HorizontalTextAlignment="Center"
-                                Text="DayRangeMaxDate"
+                                Text="NavigationUpperBound"
                                 VerticalTextAlignment="Center"/>
                             <Editor
                                 Grid.Column="1"

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/PlaygroundPage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/PlaygroundPage.xaml
@@ -600,7 +600,7 @@
                                                 CurrentMonthTextColor="{StaticResource ContentTextColor}"
                                                 DateTime="{Binding DateTime}"
                                                 HeightRequest="{Binding BindingContext.DayHeightRequest, Source={x:Reference This}}"
-                                                OutOfRangeTextColor="{StaticResource CalendarTertiaryColor}"
+                                                InvalidTextColor="{StaticResource CalendarTertiaryColor}"
                                                 SelectedTextColor="{StaticResource CalendarPrimaryTextColor}"
                                                 TodayBorderColor="{StaticResource CalendarPrimaryColor}"
                                                 TodayTextColor="{StaticResource CalendarBackgroundTextColor}"
@@ -827,7 +827,7 @@
                                                                                         <MultiTrigger.Conditions>
                                                                                             <BindingCondition Binding="{Binding IsSelected, Source={RelativeSource TemplatedParent}}" Value="True"/>
                                                                                             <BindingCondition Binding="{Binding IsCurrentMonth, Source={RelativeSource TemplatedParent}}" Value="True"/>
-                                                                                            <BindingCondition Binding="{Binding IsOutOfRange, Source={RelativeSource TemplatedParent}}" Value="False"/>
+                                                                                            <BindingCondition Binding="{Binding IsInvalid, Source={RelativeSource TemplatedParent}}" Value="False"/>
                                                                                         </MultiTrigger.Conditions>
                                                                                         <Setter Property="BackgroundColor" Value="#00A900"/>
                                                                                     </MultiTrigger>

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/PlaygroundPage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/PlaygroundPage.xaml
@@ -198,11 +198,11 @@
                                 AutoSize="TextChanges"
                                 FontSize="{StaticResource SmallFontSize}"
                                 HorizontalOptions="Center"
-                                Text="{Binding DayRangeMaximumDate, StringFormat='{0:ddd, MMM d yyy}'}"
+                                Text="{Binding NavigationUpperBound, StringFormat='{0:ddd, MMM d yyy}'}"
                                 VerticalOptions="End"/>
                             <DatePicker
                                 Grid.Column="1"
-                                Date="{Binding DayRangeMaximumDate}"
+                                Date="{Binding NavigationUpperBound}"
                                 FontSize="{StaticResource SmallFontSize}"
                                 Format="ddd, MMM d yyy"
                                 HorizontalOptions="Center"
@@ -560,7 +560,7 @@
                         CustomDayNamesOrder="{Binding CustomDayNamesOrder}"
                         DayNameTextColor="{StaticResource ContentTextColor}"
                         DayNamesHeightRequest="{Binding DayNamesHeightRequest}"
-                        DayRangeMaximumDate="{Binding DayRangeMaximumDate}"
+                        NavigationUpperBound="{Binding NavigationUpperBound}"
                         NavigationLowerBound="{Binding NavigationLowerBound}"
                         ForwardsNavigationAmount="{Binding ForwardsNavigationAmount}"
                         MonthViewHeightRequest="{Binding MonthViewHeightRequest}"

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/PlaygroundPage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/PlaygroundPage.xaml
@@ -216,19 +216,6 @@
                                 Grid.Column="0"
                                 FontSize="{StaticResource SmallFontSize}"
                                 HorizontalTextAlignment="Center"
-                                Text="ClampNavigation&#10;ToDayRange"
-                                VerticalTextAlignment="Center"/>
-                            <Switch
-                                Grid.Column="1"
-                                HorizontalOptions="Center"
-                                IsToggled="{Binding ClampNavigationToDayRange}"/>
-                        </Grid>
-
-                        <Grid>
-                            <Label
-                                Grid.Column="0"
-                                FontSize="{StaticResource SmallFontSize}"
-                                HorizontalTextAlignment="Center"
                                 Text="SelectedDates"
                                 VerticalTextAlignment="Center"/>
                             <CollectionView
@@ -570,7 +557,6 @@
                         AutoRowsIsConsistent="{Binding AutoRowsIsConsistent}"
                         BackgroundColor="{StaticResource CalendarBackgroundColor}"
                         BackwardsNavigationAmount="{Binding BackwardsNavigationAmount}"
-                        ClampNavigationToDayRange="{Binding ClampNavigationToDayRange}"
                         CustomDayNamesOrder="{Binding CustomDayNamesOrder}"
                         DayNameTextColor="{StaticResource ContentTextColor}"
                         DayNamesHeightRequest="{Binding DayNamesHeightRequest}"

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/PlaygroundPage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/PlaygroundPage.xaml
@@ -173,11 +173,11 @@
                                 AutoSize="TextChanges"
                                 FontSize="{StaticResource SmallFontSize}"
                                 HorizontalOptions="Center"
-                                Text="{Binding DayRangeMinimumDate, StringFormat='{0:ddd, MMM d yyy}'}"
+                                Text="{Binding NavigationLowerBound, StringFormat='{0:ddd, MMM d yyy}'}"
                                 VerticalOptions="End"/>
                             <DatePicker
                                 Grid.Column="1"
-                                Date="{Binding DayRangeMinimumDate, StringFormat='{0:ddd, MMM d yyy}'}"
+                                Date="{Binding NavigationLowerBound, StringFormat='{0:ddd, MMM d yyy}'}"
                                 FontSize="{StaticResource SmallFontSize}"
                                 Format="ddd, MMM d yyy"
                                 HorizontalOptions="Center"
@@ -561,7 +561,7 @@
                         DayNameTextColor="{StaticResource ContentTextColor}"
                         DayNamesHeightRequest="{Binding DayNamesHeightRequest}"
                         DayRangeMaximumDate="{Binding DayRangeMaximumDate}"
-                        DayRangeMinimumDate="{Binding DayRangeMinimumDate}"
+                        NavigationLowerBound="{Binding NavigationLowerBound}"
                         ForwardsNavigationAmount="{Binding ForwardsNavigationAmount}"
                         MonthViewHeightRequest="{Binding MonthViewHeightRequest}"
                         NavigatedDate="{Binding NavigatedDate}"

--- a/XCalendarMauiSample/Popups/DatePickerDialogPopup.xaml
+++ b/XCalendarMauiSample/Popups/DatePickerDialogPopup.xaml
@@ -79,7 +79,7 @@
                         FontSize="12"
                         HeightRequest="41"
                         OtherMonthTextColor="Transparent"
-                        OutOfRangeBackgroundColor="Transparent"
+                        InvalidBackgroundColor="Transparent"
                         SelectedBackgroundColor="{StaticResource PrimaryPickerColor}"
                         SelectedTextColor="White"
                         TodayBackgroundColor="Transparent"

--- a/XCalendarMauiSample/ViewModels/PlaygroundViewModel.cs
+++ b/XCalendarMauiSample/ViewModels/PlaygroundViewModel.cs
@@ -33,7 +33,7 @@ namespace XCalendarMauiSample.ViewModels
         };
         public DateTime NavigatedDate { get; set; } = DateTime.Today;
         public DateTime NavigationLowerBound { get; set; } = DateTime.Today.AddYears(-2);
-        public DateTime DayRangeMaximumDate { get; set; } = DateTime.Today.AddYears(2);
+        public DateTime NavigationUpperBound { get; set; } = DateTime.Today.AddYears(2);
         public DayOfWeek StartOfWeek { get; set; } = DayOfWeek.Monday;
         public ObservableRangeCollection<DayOfWeek> CustomDayNamesOrder { get; } = new ObservableRangeCollection<DayOfWeek>()
         {

--- a/XCalendarMauiSample/ViewModels/PlaygroundViewModel.cs
+++ b/XCalendarMauiSample/ViewModels/PlaygroundViewModel.cs
@@ -59,7 +59,6 @@ namespace XCalendarMauiSample.ViewModels
         public double DayNamesHeightRequest { get; set; } = 25;
         public bool UseCustomDayNamesOrder { get; set; } = false;
         public DateTime TodayDate { get; set; } = DateTime.Today;
-        public bool ClampNavigationToDayRange { get; set; } = true;
         public double NavigationHeightRequest { get; set; } = 40;
         public int ForwardsNavigationAmount { get; set; } = 1;
         public int BackwardsNavigationAmount { get; set; } = -1;

--- a/XCalendarMauiSample/ViewModels/PlaygroundViewModel.cs
+++ b/XCalendarMauiSample/ViewModels/PlaygroundViewModel.cs
@@ -32,7 +32,7 @@ namespace XCalendarMauiSample.ViewModels
             DayOfWeek.Sunday
         };
         public DateTime NavigatedDate { get; set; } = DateTime.Today;
-        public DateTime DayRangeMinimumDate { get; set; } = DateTime.Today.AddYears(-2);
+        public DateTime NavigationLowerBound { get; set; } = DateTime.Today.AddYears(-2);
         public DateTime DayRangeMaximumDate { get; set; } = DateTime.Today.AddYears(2);
         public DayOfWeek StartOfWeek { get; set; } = DayOfWeek.Monday;
         public ObservableRangeCollection<DayOfWeek> CustomDayNamesOrder { get; } = new ObservableRangeCollection<DayOfWeek>()

--- a/XCalendarMauiSample/Views/EventCalendarExamplePage.xaml
+++ b/XCalendarMauiSample/Views/EventCalendarExamplePage.xaml
@@ -58,7 +58,7 @@
                                 CalendarView="{Binding ., Source={x:Reference MainCalendarView}}"
                                 CurrentMonthTextColor="{StaticResource CalendarBackgroundTextColor}"
                                 DateTime="{Binding DateTime}"
-                                OutOfRangeTextColor="{StaticResource CalendarTertiaryColor}"
+                                InvalidTextColor="{StaticResource CalendarTertiaryColor}"
                                 SelectedTextColor="{StaticResource CalendarPrimaryTextColor}"
                                 TodayBorderColor="{StaticResource CalendarPrimaryColor}"
                                 TodayTextColor="{StaticResource CalendarBackgroundTextColor}">
@@ -101,7 +101,7 @@
                                                         <Binding Path="IsCurrentMonth" Source="{RelativeSource TemplatedParent}"/>
                                                         <Binding
                                                             Converter="{StaticResource InvertedBoolConverter}"
-                                                            Path="IsOutOfRange"
+                                                            Path="IsInvalid"
                                                             Source="{RelativeSource TemplatedParent}"/>
                                                     </MultiBinding>
                                                 </HorizontalStackLayout.IsVisible>

--- a/XCalendarMauiSample/Views/PlaygroundPage.xaml
+++ b/XCalendarMauiSample/Views/PlaygroundPage.xaml
@@ -177,21 +177,21 @@
                                 TextColor="Transparent"/>
                         </Grid>
 
-                        <Grid>
-                            <Label
+                    <Grid>
+                        <Label
                                 Grid.Column="0"
                                 FontSize="{StaticResource SmallFontSize}"
                                 HorizontalTextAlignment="Center"
                                 Text="DayRangeMaxDate"
                                 VerticalTextAlignment="Center"/>
-                            <Editor
+                        <Editor
                                 Grid.Column="1"
                                 AutoSize="TextChanges"
                                 FontSize="{StaticResource SmallFontSize}"
                                 HorizontalOptions="Center"
                                 Text="{Binding DayRangeMaximumDate, StringFormat='{0:ddd, MMM d yyy}'}"
                                 VerticalOptions="End"/>
-                            <DatePicker
+                        <DatePicker
                                 Grid.Column="1"
                                 Date="{Binding DayRangeMaximumDate}"
                                 FontSize="{StaticResource SmallFontSize}"
@@ -200,22 +200,9 @@
                                 MaximumDate="{x:Static System:DateTime.MaxValue}"
                                 MinimumDate="{x:Static System:DateTime.MinValue}"
                                 TextColor="Transparent"/>
-                        </Grid>
+                    </Grid>
 
-                        <Grid>
-                            <Label
-                                Grid.Column="0"
-                                FontSize="{StaticResource SmallFontSize}"
-                                HorizontalTextAlignment="Center"
-                                Text="ClampNavigation&#10;ToDayRange"
-                                VerticalTextAlignment="Center"/>
-                            <Switch
-                                Grid.Column="1"
-                                HorizontalOptions="Center"
-                                IsToggled="{Binding ClampNavigationToDayRange}"/>
-                        </Grid>
-
-                        <Grid>
+                    <Grid>
                             <Label
                                 Grid.Column="0"
                                 FontSize="{StaticResource SmallFontSize}"
@@ -587,7 +574,6 @@
                         AutoRowsIsConsistent="{Binding AutoRowsIsConsistent}"
                         BackgroundColor="{StaticResource CalendarBackgroundColor}"
                         BackwardsNavigationAmount="{Binding BackwardsNavigationAmount}"
-                        ClampNavigationToDayRange="{Binding ClampNavigationToDayRange}"
                         CustomDayNamesOrder="{Binding CustomDayNamesOrder}"
                         DayNameTextColor="{StaticResource ContentTextColor}"
                         DayNamesHeightRequest="{Binding DayNamesHeightRequest}"

--- a/XCalendarMauiSample/Views/PlaygroundPage.xaml
+++ b/XCalendarMauiSample/Views/PlaygroundPage.xaml
@@ -189,11 +189,11 @@
                                 AutoSize="TextChanges"
                                 FontSize="{StaticResource SmallFontSize}"
                                 HorizontalOptions="Center"
-                                Text="{Binding DayRangeMaximumDate, StringFormat='{0:ddd, MMM d yyy}'}"
+                                Text="{Binding NavigationUpperBound, StringFormat='{0:ddd, MMM d yyy}'}"
                                 VerticalOptions="End"/>
                         <DatePicker
                                 Grid.Column="1"
-                                Date="{Binding DayRangeMaximumDate}"
+                                Date="{Binding NavigationUpperBound}"
                                 FontSize="{StaticResource SmallFontSize}"
                                 Format="ddd, MMM d yyy"
                                 HorizontalOptions="Center"
@@ -577,7 +577,7 @@
                         CustomDayNamesOrder="{Binding CustomDayNamesOrder}"
                         DayNameTextColor="{StaticResource ContentTextColor}"
                         DayNamesHeightRequest="{Binding DayNamesHeightRequest}"
-                        DayRangeMaximumDate="{Binding DayRangeMaximumDate}"
+                        NavigationUpperBound="{Binding NavigationUpperBound}"
                         NavigationLowerBound="{Binding NavigationLowerBound}"
                         ForwardsNavigationAmount="{Binding ForwardsNavigationAmount}"
                         MonthViewHeightRequest="{Binding MonthViewHeightRequest}"

--- a/XCalendarMauiSample/Views/PlaygroundPage.xaml
+++ b/XCalendarMauiSample/Views/PlaygroundPage.xaml
@@ -617,7 +617,7 @@
                                                 CurrentMonthTextColor="{StaticResource ContentTextColor}"
                                                 DateTime="{Binding DateTime}"
                                                 HeightRequest="{Binding BindingContext.DayHeightRequest, Source={x:Reference This}}"
-                                                OutOfRangeTextColor="{StaticResource CalendarTertiaryColor}"
+                                                InvalidTextColor="{StaticResource CalendarTertiaryColor}"
                                                 SelectedTextColor="{StaticResource CalendarPrimaryTextColor}"
                                                 TodayBorderColor="{StaticResource CalendarPrimaryColor}"
                                                 TodayTextColor="{StaticResource CalendarBackgroundTextColor}"
@@ -855,7 +855,7 @@
                                                                                         <MultiTrigger.Conditions>
                                                                                             <BindingCondition Binding="{Binding IsSelected, Source={RelativeSource TemplatedParent}}" Value="True"/>
                                                                                             <BindingCondition Binding="{Binding IsCurrentMonth, Source={RelativeSource TemplatedParent}}" Value="True"/>
-                                                                                            <BindingCondition Binding="{Binding IsOutOfRange, Source={RelativeSource TemplatedParent}}" Value="False"/>
+                                                                                            <BindingCondition Binding="{Binding IsInvalid, Source={RelativeSource TemplatedParent}}" Value="False"/>
                                                                                         </MultiTrigger.Conditions>
                                                                                         <Setter Property="BackgroundColor" Value="#00A900"/>
                                                                                     </MultiTrigger>

--- a/XCalendarMauiSample/Views/PlaygroundPage.xaml
+++ b/XCalendarMauiSample/Views/PlaygroundPage.xaml
@@ -157,7 +157,7 @@
                                 Grid.Column="0"
                                 FontSize="{StaticResource SmallFontSize}"
                                 HorizontalTextAlignment="Center"
-                                Text="DayRangeMinDate"
+                                Text="NavigationLowerBound"
                                 VerticalTextAlignment="Center"/>
                             <Editor
                                 Grid.Column="1"
@@ -182,7 +182,7 @@
                                 Grid.Column="0"
                                 FontSize="{StaticResource SmallFontSize}"
                                 HorizontalTextAlignment="Center"
-                                Text="DayRangeMaxDate"
+                                Text="NavigationUpperBound"
                                 VerticalTextAlignment="Center"/>
                         <Editor
                                 Grid.Column="1"

--- a/XCalendarMauiSample/Views/PlaygroundPage.xaml
+++ b/XCalendarMauiSample/Views/PlaygroundPage.xaml
@@ -164,11 +164,11 @@
                                 AutoSize="TextChanges"
                                 FontSize="{StaticResource SmallFontSize}"
                                 HorizontalOptions="Center"
-                                Text="{Binding DayRangeMinimumDate, StringFormat='{0:ddd, MMM d yyy}'}"
+                                Text="{Binding NavigationLowerBound, StringFormat='{0:ddd, MMM d yyy}'}"
                                 VerticalOptions="End"/>
                             <DatePicker
                                 Grid.Column="1"
-                                Date="{Binding DayRangeMinimumDate, StringFormat='{0:ddd, MMM d yyy}'}"
+                                Date="{Binding NavigationLowerBound, StringFormat='{0:ddd, MMM d yyy}'}"
                                 FontSize="{StaticResource SmallFontSize}"
                                 Format="ddd, MMM d yyy"
                                 HorizontalOptions="Center"
@@ -578,7 +578,7 @@
                         DayNameTextColor="{StaticResource ContentTextColor}"
                         DayNamesHeightRequest="{Binding DayNamesHeightRequest}"
                         DayRangeMaximumDate="{Binding DayRangeMaximumDate}"
-                        DayRangeMinimumDate="{Binding DayRangeMinimumDate}"
+                        NavigationLowerBound="{Binding NavigationLowerBound}"
                         ForwardsNavigationAmount="{Binding ForwardsNavigationAmount}"
                         MonthViewHeightRequest="{Binding MonthViewHeightRequest}"
                         NavigatedDate="{Binding NavigatedDate}"


### PR DESCRIPTION
Removed property `ClampNavigationToDayRange` in CalendarView as it is redundant; the developer can just change the values of `DayRangeMinimumDate` and `DayRangeMaximumDate`.

Renamed properties `DayRangeMinimumDate`,`DayRangeMaxmimumDate` to `NavigationLowerBound` and `NavigationUpperBound` in CalendarView and renamed `DayState.OutOfRange` to `DayState.Invalid`.

These changes make it clearer that these are decoupled and that CalendarDayView's `DayState` can be set to `DayState.OutOfRange` for any reason the developer specifies by inheriting from CalendarDayView's `IsDateTimeOutOfRange` method.