### PR TITLE
Remove redundant view in 'DaysView' implementations in Maui projects

### DIFF
--- a/XCalendar.Maui/Views/DaysView.xaml
+++ b/XCalendar.Maui/Views/DaysView.xaml
@@ -24,22 +24,19 @@
                 <Setter Property="ItemTemplate">
                     <Setter.Value>
                         <DataTemplate x:DataType="{x:Type xcInterfaces:ICalendarDay}">
-                            <!--  Needs to be nested because collectionview doesn't respect margins  -->
-                            <ContentView>
-                                <Border Margin="2.5" BackgroundColor="Transparent">
+                            <Border Margin="2.5" BackgroundColor="Transparent">
 
-                                    <Border.StrokeShape>
-                                        <Ellipse/>
-                                    </Border.StrokeShape>
+                                <Border.StrokeShape>
+                                    <Ellipse/>
+                                </Border.StrokeShape>
 
-                                    <xc:DayView
+                                <xc:DayView
                                         DateTime="{Binding DateTime}"
                                         IsCurrentMonth="{Binding IsCurrentMonth}"
                                         IsInvalid="{Binding IsInvalid}"
                                         IsSelected="{Binding IsSelected}"
                                         IsToday="{Binding IsToday}"/>
-                                </Border>
-                            </ContentView>
+                            </Border>
                         </DataTemplate>
                     </Setter.Value>
                 </Setter>

--- a/XCalendarMauiSample/Views/CustomisingADayExamplePage.xaml
+++ b/XCalendarMauiSample/Views/CustomisingADayExamplePage.xaml
@@ -38,14 +38,13 @@
 
             <xc:CalendarView.DayTemplate>
                 <DataTemplate x:DataType="{x:Type xcModels:CalendarDay}">
-                    <ContentView>
-                        <Border Margin="2.5" BackgroundColor="Transparent">
+                    <Border Margin="2.5" BackgroundColor="Transparent">
 
-                            <Border.StrokeShape>
-                                <Ellipse/>
-                            </Border.StrokeShape>
+                        <Border.StrokeShape>
+                            <Ellipse/>
+                        </Border.StrokeShape>
 
-                            <xc:DayView
+                        <xc:DayView
                                 CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
                                 CurrentMonthCommandParameter="{Binding DateTime}"
                                 DateTime="{Binding DateTime}"
@@ -60,8 +59,7 @@
                                 Style="{StaticResource DefaultDayViewStyle}"
                                 TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
                                 TodayCommandParameter="{Binding DateTime}"/>
-                        </Border>
-                    </ContentView>
+                    </Border>
                 </DataTemplate>
             </xc:CalendarView.DayTemplate>
         </xc:CalendarView>

--- a/XCalendarMauiSample/Views/EventCalendarExamplePage.xaml
+++ b/XCalendarMauiSample/Views/EventCalendarExamplePage.xaml
@@ -67,14 +67,13 @@
                 <xc:CalendarView.DayTemplate>
                     <DataTemplate x:DataType="{x:Type Models:EventDay}">
                         <!--  ContentView so that the margin is respected by the DaysView  -->
-                        <ContentView>
-                            <Border Margin="2.5" BackgroundColor="Transparent">
-                                
-                                <Border.StrokeShape>
-                                    <Ellipse/>
-                                </Border.StrokeShape>
-                                
-                                <xc:DayView
+                        <Border Margin="2.5" BackgroundColor="Transparent">
+
+                            <Border.StrokeShape>
+                                <Ellipse/>
+                            </Border.StrokeShape>
+
+                            <xc:DayView
                                     CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
                                     CurrentMonthCommandParameter="{Binding DateTime}"
                                     DateTime="{Binding DateTime}"
@@ -89,59 +88,58 @@
                                     TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
                                     TodayCommandParameter="{Binding DateTime}">
 
-                                    <xc:DayView.ControlTemplate>
-                                        <ControlTemplate>
-                                            <!--  Using a Grid to stack views on the z axis  -->
-                                            <!--  TemplatedParent refers to the view that the ControlTemplate resides in  -->
-                                            <Grid BindingContext="{Binding BindingContext, Source={RelativeSource TemplatedParent}}" RowSpacing="2">
+                                <xc:DayView.ControlTemplate>
+                                    <ControlTemplate>
+                                        <!--  Using a Grid to stack views on the z axis  -->
+                                        <!--  TemplatedParent refers to the view that the ControlTemplate resides in  -->
+                                        <Grid BindingContext="{Binding BindingContext, Source={RelativeSource TemplatedParent}}" RowSpacing="2">
 
-                                                <Grid.RowDefinitions>
-                                                    <RowDefinition Height="1.5*"/>
-                                                    <RowDefinition/>
-                                                </Grid.RowDefinitions>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="1.5*"/>
+                                                <RowDefinition/>
+                                            </Grid.RowDefinitions>
 
-                                                <!--  ContentPresenter displays the default content for the control  -->
-                                                <ContentPresenter
+                                            <!--  ContentPresenter displays the default content for the control  -->
+                                            <ContentPresenter
                                                     Grid.Row="0"
                                                     Grid.RowSpan="2"
                                                     VerticalOptions="Center"/>
 
-                                                <StackLayout
+                                            <StackLayout
                                                     Grid.Row="1"
                                                     BindableLayout.ItemsSource="{Binding Events}"
                                                     HorizontalOptions="Center"
                                                     Orientation="Horizontal"
                                                     Spacing="2.5">
 
-                                                    <!--  I want the event indicators to only be visible when the DateTime is in the currently navigated month  -->
-                                                    <StackLayout.IsVisible>
-                                                        <MultiBinding Converter="{StaticResource AllTrueConverter}">
-                                                            <Binding Path="IsCurrentMonth"/>
-                                                            <Binding Converter="{StaticResource InvertedBoolConverter}" Path="IsInvalid"/>
-                                                        </MultiBinding>
-                                                    </StackLayout.IsVisible>
+                                                <!--  I want the event indicators to only be visible when the DateTime is in the currently navigated month  -->
+                                                <StackLayout.IsVisible>
+                                                    <MultiBinding Converter="{StaticResource AllTrueConverter}">
+                                                        <Binding Path="IsCurrentMonth"/>
+                                                        <Binding Converter="{StaticResource InvertedBoolConverter}" Path="IsInvalid"/>
+                                                    </MultiBinding>
+                                                </StackLayout.IsVisible>
 
-                                                    <BindableLayout.ItemTemplate>
-                                                        <DataTemplate x:DataType="{x:Type Models:Event}">
-                                                            <BoxView
+                                                <BindableLayout.ItemTemplate>
+                                                    <DataTemplate x:DataType="{x:Type Models:Event}">
+                                                        <BoxView
                                                                 CornerRadius="100"
                                                                 HeightRequest="7"
                                                                 HorizontalOptions="CenterAndExpand"
                                                                 VerticalOptions="Center"
                                                                 WidthRequest="7"
                                                                 Color="{Binding Color}"/>
-                                                        </DataTemplate>
-                                                    </BindableLayout.ItemTemplate>
+                                                    </DataTemplate>
+                                                </BindableLayout.ItemTemplate>
 
-                                                </StackLayout>
+                                            </StackLayout>
 
-                                            </Grid>
-                                        </ControlTemplate>
-                                    </xc:DayView.ControlTemplate>
+                                        </Grid>
+                                    </ControlTemplate>
+                                </xc:DayView.ControlTemplate>
 
-                                </xc:DayView>
-                            </Border>
-                        </ContentView>
+                            </xc:DayView>
+                        </Border>
                     </DataTemplate>
                 </xc:CalendarView.DayTemplate>
 

--- a/XCalendarMauiSample/Views/PlaygroundPage.xaml
+++ b/XCalendarMauiSample/Views/PlaygroundPage.xaml
@@ -998,40 +998,38 @@
 
                 <xc:CalendarView.DayTemplate>
                     <DataTemplate x:DataType="{x:Type xcModels:CalendarDay}">
-                        <ContentView>
-                            <Border Margin="2.5" BackgroundColor="Transparent">
+                        <Border Margin="2.5" BackgroundColor="Transparent">
 
-                                <Border.StrokeShape>
-                                    <Ellipse/>
-                                </Border.StrokeShape>
+                            <Border.StrokeShape>
+                                <Ellipse/>
+                            </Border.StrokeShape>
 
-                                <xc:DayView
-                                    CurrentMonthBackgroundColor="{Binding BindingContext.DayCurrentMonthBackgroundColor, Source={x:Reference This}}"
-                                    CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                    CurrentMonthCommandParameter="{Binding DateTime}"
-                                    CurrentMonthTextColor="{Binding BindingContext.DayCurrentMonthTextColor, Source={x:Reference This}}"
-                                    DateTime="{Binding DateTime}"
-                                    HeightRequest="{Binding BindingContext.DayHeightRequest, Source={x:Reference This}}"
-                                    InvalidBackgroundColor="{Binding BindingContext.DayInvalidBackgroundColor, Source={x:Reference This}}"
-                                    InvalidTextColor="{Binding BindingContext.DayInvalidTextColor, Source={x:Reference This}}"
-                                    IsCurrentMonth="{Binding IsCurrentMonth}"
-                                    IsInvalid="{Binding IsInvalid}"
-                                    IsSelected="{Binding IsSelected}"
-                                    IsToday="{Binding IsToday}"
-                                    OtherMonthBackgroundColor="{Binding BindingContext.DayOtherMonthBackgroundColor, Source={x:Reference This}}"
-                                    OtherMonthTextColor="{Binding BindingContext.DayOtherMonthTextColor, Source={x:Reference This}}"
-                                    SelectedBackgroundColor="{Binding BindingContext.DaySelectedBackgroundColor, Source={x:Reference This}}"
-                                    SelectedCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                    SelectedCommandParameter="{Binding DateTime}"
-                                    SelectedTextColor="{Binding BindingContext.DaySelectedTextColor, Source={x:Reference This}}"
-                                    Style="{StaticResource DefaultDayViewStyle}"
-                                    TodayBackgroundColor="{Binding BindingContext.DayTodayBackgroundColor, Source={x:Reference This}}"
-                                    TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                    TodayCommandParameter="{Binding DateTime}"
-                                    TodayTextColor="{Binding BindingContext.DayTodayTextColor, Source={x:Reference This}}"
-                                    WidthRequest="{Binding BindingContext.DayWidthRequest, Source={x:Reference This}}"/>
-                            </Border>
-                        </ContentView>
+                            <xc:DayView
+                                CurrentMonthBackgroundColor="{Binding BindingContext.DayCurrentMonthBackgroundColor, Source={x:Reference This}}"
+                                CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
+                                CurrentMonthCommandParameter="{Binding DateTime}"
+                                CurrentMonthTextColor="{Binding BindingContext.DayCurrentMonthTextColor, Source={x:Reference This}}"
+                                DateTime="{Binding DateTime}"
+                                HeightRequest="{Binding BindingContext.DayHeightRequest, Source={x:Reference This}}"
+                                InvalidBackgroundColor="{Binding BindingContext.DayInvalidBackgroundColor, Source={x:Reference This}}"
+                                InvalidTextColor="{Binding BindingContext.DayInvalidTextColor, Source={x:Reference This}}"
+                                IsCurrentMonth="{Binding IsCurrentMonth}"
+                                IsInvalid="{Binding IsInvalid}"
+                                IsSelected="{Binding IsSelected}"
+                                IsToday="{Binding IsToday}"
+                                OtherMonthBackgroundColor="{Binding BindingContext.DayOtherMonthBackgroundColor, Source={x:Reference This}}"
+                                OtherMonthTextColor="{Binding BindingContext.DayOtherMonthTextColor, Source={x:Reference This}}"
+                                SelectedBackgroundColor="{Binding BindingContext.DaySelectedBackgroundColor, Source={x:Reference This}}"
+                                SelectedCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
+                                SelectedCommandParameter="{Binding DateTime}"
+                                SelectedTextColor="{Binding BindingContext.DaySelectedTextColor, Source={x:Reference This}}"
+                                Style="{StaticResource DefaultDayViewStyle}"
+                                TodayBackgroundColor="{Binding BindingContext.DayTodayBackgroundColor, Source={x:Reference This}}"
+                                TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
+                                TodayCommandParameter="{Binding DateTime}"
+                                TodayTextColor="{Binding BindingContext.DayTodayTextColor, Source={x:Reference This}}"
+                                WidthRequest="{Binding BindingContext.DayWidthRequest, Source={x:Reference This}}"/>
+                        </Border>
                     </DataTemplate>
                 </xc:CalendarView.DayTemplate>
 

--- a/XCalendarMauiSample/Views/SelectionExamplePage.xaml
+++ b/XCalendarMauiSample/Views/SelectionExamplePage.xaml
@@ -52,14 +52,13 @@
                 <!--  Not Required, used only for styling.  -->
                 <xc:CalendarView.DayTemplate>
                     <DataTemplate x:DataType="{x:Type xcInterfaces:ICalendarDay}">
-                        <ContentView>
-                            <Border Margin="2.5" BackgroundColor="Transparent">
+                        <Border Margin="2.5" BackgroundColor="Transparent">
 
-                                <Border.StrokeShape>
-                                    <Ellipse/>
-                                </Border.StrokeShape>
+                            <Border.StrokeShape>
+                                <Ellipse/>
+                            </Border.StrokeShape>
 
-                                <xc:DayView
+                            <xc:DayView
                                     CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
                                     CurrentMonthCommandParameter="{Binding DateTime}"
                                     DateTime="{Binding DateTime}"
@@ -72,8 +71,7 @@
                                     Style="{StaticResource DefaultDayViewStyle}"
                                     TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
                                     TodayCommandParameter="{Binding DateTime}"/>
-                            </Border>
-                        </ContentView>
+                        </Border>
                     </DataTemplate>
                 </xc:CalendarView.DayTemplate>
 

--- a/XCalendarMauiSample/Views/UsingDayViewExamplePage.xaml
+++ b/XCalendarMauiSample/Views/UsingDayViewExamplePage.xaml
@@ -39,15 +39,14 @@
 
                 <xc:CalendarView.DayTemplate>
                     <DataTemplate x:DataType="{x:Type xcModels:CalendarDay}">
-                        <ContentView>
-                            <!--  Inside the CalendarView  -->
-                            <Border Margin="2.5" BackgroundColor="Transparent">
+                        <!--  Inside the CalendarView  -->
+                        <Border Margin="2.5" BackgroundColor="Transparent">
 
-                                <Border.StrokeShape>
-                                    <Ellipse/>
-                                </Border.StrokeShape>
+                            <Border.StrokeShape>
+                                <Ellipse/>
+                            </Border.StrokeShape>
 
-                                <xc:DayView
+                            <xc:DayView
                                     CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
                                     CurrentMonthCommandParameter="{Binding DateTime}"
                                     DateTime="{Binding DateTime}"
@@ -62,8 +61,7 @@
                                     TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
                                     TodayCommandParameter="{Binding DateTime}"/>
 
-                            </Border>
-                        </ContentView>
+                        </Border>
                     </DataTemplate>
                 </xc:CalendarView.DayTemplate>
             </xc:CalendarView>


### PR DESCRIPTION
This should improve the performance of the default implementation of the calendar in XCalendar.Maui.