### PR TITLE
Remove property 'NavigatedDate' from DaysView

### DIFF
--- a/XCalendar.Forms/Views/CalendarView.xaml
+++ b/XCalendar.Forms/Views/CalendarView.xaml
@@ -87,8 +87,7 @@
             ControlTemplate="{Binding DaysViewTemplate, Source={x:Reference CalendarView_Unique}}"
             DayTemplate="{Binding DayTemplate, Source={x:Reference CalendarView_Unique}}"
             DaysOfWeek="{Binding DaysOfWeek, Source={x:Reference CalendarView_Unique}}"
-            HeightRequest="{Binding DaysViewHeightRequest, Source={x:Reference CalendarView_Unique}}"
-            NavigatedDate="{Binding NavigatedDate, Source={x:Reference CalendarView_Unique}}"/>
+            HeightRequest="{Binding DaysViewHeightRequest, Source={x:Reference CalendarView_Unique}}"/>
 
     </StackLayout>
 

--- a/XCalendar.Forms/Views/DaysView.xaml.cs
+++ b/XCalendar.Forms/Views/DaysView.xaml.cs
@@ -12,11 +12,6 @@ namespace XCalendar.Forms.Views
         #region Properties
 
         #region Bindable Properties
-        public DateTime NavigatedDate
-        {
-            get { return (DateTime)GetValue(NavigatedDateProperty); }
-            set { SetValue(NavigatedDateProperty, value); }
-        }
         public IEnumerable<ICalendarDay> Days
         {
             get { return (IEnumerable<ICalendarDay>)GetValue(DaysProperty); }
@@ -37,7 +32,6 @@ namespace XCalendar.Forms.Views
         }
 
         #region Bindable Properties Initialisers
-        public static readonly BindableProperty NavigatedDateProperty = BindableProperty.Create(nameof(NavigatedDate), typeof(DateTime), typeof(DaysView), DateTime.Today);
         public static readonly BindableProperty DaysProperty = BindableProperty.Create(nameof(DaysProperty), typeof(IEnumerable<ICalendarDay>), typeof(DaysView), propertyChanged: DaysPropertyChanged);
         public static readonly BindableProperty DaysOfWeekProperty = BindableProperty.Create(nameof(DaysOfWeek), typeof(IList<DayOfWeek>), typeof(DaysView));
         public static readonly BindableProperty DayTemplateProperty = BindableProperty.Create(nameof(DayTemplate), typeof(DataTemplate), typeof(DaysView));

--- a/XCalendar.Maui/Views/CalendarView.xaml
+++ b/XCalendar.Maui/Views/CalendarView.xaml
@@ -93,8 +93,7 @@
             ControlTemplate="{Binding DaysViewTemplate, Source={x:Reference CalendarView_Unique}}"
             DayTemplate="{Binding DayTemplate, Source={x:Reference CalendarView_Unique}}"
             DaysOfWeek="{Binding DaysOfWeek, Source={x:Reference CalendarView_Unique}}"
-            HeightRequest="{Binding DaysViewHeightRequest, Source={x:Reference CalendarView_Unique}}"
-            NavigatedDate="{Binding NavigatedDate, Source={x:Reference CalendarView_Unique}}"/>
+            HeightRequest="{Binding DaysViewHeightRequest, Source={x:Reference CalendarView_Unique}}"/>
 
     </VerticalStackLayout>
 

--- a/XCalendar.Maui/Views/DaysView.xaml.cs
+++ b/XCalendar.Maui/Views/DaysView.xaml.cs
@@ -7,11 +7,6 @@ namespace XCalendar.Maui.Views
         #region Properties
 
         #region Bindable Properties
-        public DateTime NavigatedDate
-        {
-            get { return (DateTime)GetValue(NavigatedDateProperty); }
-            set { SetValue(NavigatedDateProperty, value); }
-        }
         public IEnumerable<ICalendarDay> Days
         {
             get { return (IEnumerable<ICalendarDay>)GetValue(DaysProperty); }
@@ -32,7 +27,6 @@ namespace XCalendar.Maui.Views
         }
 
         #region Bindable Properties Initialisers
-        public static readonly BindableProperty NavigatedDateProperty = BindableProperty.Create(nameof(NavigatedDate), typeof(DateTime), typeof(DaysView), DateTime.Today);
         public static readonly BindableProperty DaysProperty = BindableProperty.Create(nameof(DaysProperty), typeof(IEnumerable<ICalendarDay>), typeof(DaysView), propertyChanged: DaysPropertyChanged);
         public static readonly BindableProperty DaysOfWeekProperty = BindableProperty.Create(nameof(DaysOfWeek), typeof(IList<DayOfWeek>), typeof(DaysView));
         public static readonly BindableProperty DayTemplateProperty = BindableProperty.Create(nameof(DayTemplate), typeof(DataTemplate), typeof(DaysView));


### PR DESCRIPTION
It is not required when determining the apperance or behaviour of the DaysView.