### PR TITLE
Remove properties 'ForwardsNavigationAmount' and 'BackwardsNavigationAmount' from Calendar

### DIFF
--- a/XCalendar.Core/Interfaces/ICalendar.cs
+++ b/XCalendar.Core/Interfaces/ICalendar.cs
@@ -25,8 +25,6 @@ namespace XCalendar.Core.Interfaces
         NavigationTimeUnit NavigationTimeUnit { get; set; }
         PageStartMode PageStartMode { get; set; }
         ObservableRangeCollection<DayOfWeek> DayNamesOrder { get; }
-        int ForwardsNavigationAmount { get; set; }
-        int BackwardsNavigationAmount { get; set; }
         DateTime? RangeSelectionStart { get; set; }
         DateTime? RangeSelectionEnd { get; set; }
         SelectionType SelectionType { get; set; }

--- a/XCalendar.Core/Models/Calendar.cs
+++ b/XCalendar.Core/Models/Calendar.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Data.SqlTypes;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -34,8 +33,6 @@ namespace XCalendar.Core.Models
         private NavigationTimeUnit _NavigationTimeUnit = NavigationTimeUnit.Month;
         private PageStartMode _PageStartMode = PageStartMode.FirstDayOfMonth;
         private ObservableRangeCollection<DayOfWeek> _DayNamesOrder = new ObservableRangeCollection<DayOfWeek>();
-        private int _ForwardsNavigationAmount = 1;
-        private int _BackwardsNavigationAmount = -1;
         private DateTime? _RangeSelectionStart;
         private DateTime? _RangeSelectionEnd;
         private SelectionType _SelectionType = SelectionType.None;
@@ -378,38 +375,6 @@ namespace XCalendar.Core.Models
 
                     OnDayNamesOrderChanged(OldValue, _DayNamesOrder);
                     OnPropertyChanged(nameof(DayNamesOrder));
-                }
-            }
-        }
-        public int ForwardsNavigationAmount
-        {
-            get
-            {
-                return _ForwardsNavigationAmount;
-            }
-            set
-            {
-                if (_ForwardsNavigationAmount != value)
-                {
-                    _ForwardsNavigationAmount = value;
-
-                    OnPropertyChanged(nameof(ForwardsNavigationAmount));
-                }
-            }
-        }
-        public int BackwardsNavigationAmount
-        {
-            get
-            {
-                return _BackwardsNavigationAmount;
-            }
-            set
-            {
-                if (_BackwardsNavigationAmount != value)
-                {
-                    _BackwardsNavigationAmount = value;
-
-                    OnPropertyChanged(nameof(BackwardsNavigationAmount));
                 }
             }
         }

--- a/XCalendarConsoleSample/Program.cs
+++ b/XCalendarConsoleSample/Program.cs
@@ -24,9 +24,7 @@ namespace XCalendarConsoleSample
             Rows = 2,
             AutoRows = true,
             AutoRowsIsConsistent = true,
-            TodayDate = DateTime.Today,
-            ForwardsNavigationAmount = 1,
-            BackwardsNavigationAmount = -1
+            TodayDate = DateTime.Today
         };
         static void Main(string[] args)
         {

--- a/XCalendarFormsSample/XCalendarFormsSample/Popups/DatePickerDialogPopup.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Popups/DatePickerDialogPopup.xaml
@@ -60,12 +60,12 @@
             Margin="0,5,0,0"
             Padding="20,0,20,0"
             BackwardsArrowCommand="{Binding NavigateCalendarCommand, Source={x:Reference This}}"
-            BackwardsArrowCommandParameter="{Binding Calendar.BackwardsNavigationAmount, Source={x:Reference This}}"
+            BackwardsArrowCommandParameter="{Binding BackwardsNavigationAmount, Source={x:Reference This}}"
             Days="{Binding Calendar.Days, Source={x:Reference This}}"
             DaysOfWeek="{Binding Calendar.DayNamesOrder, Source={x:Reference This}}"
             DaysViewHeightRequest="246"
             ForwardsArrowCommand="{Binding NavigateCalendarCommand, Source={x:Reference This}}"
-            ForwardsArrowCommandParameter="{Binding Calendar.ForwardsNavigationAmount, Source={x:Reference This}}"
+            ForwardsArrowCommandParameter="{Binding ForwardsNavigationAmount, Source={x:Reference This}}"
             NavigatedDate="{Binding Calendar.NavigatedDate, Source={x:Reference This}}">
 
             <xc:CalendarView.NavigationViewTemplate>

--- a/XCalendarFormsSample/XCalendarFormsSample/Popups/DatePickerDialogPopup.xaml.cs
+++ b/XCalendarFormsSample/XCalendarFormsSample/Popups/DatePickerDialogPopup.xaml.cs
@@ -25,6 +25,8 @@ namespace XCalendarFormsSample.Popups
             SelectionAction = SelectionAction.Replace,
             SelectionType = SelectionType.Single
         };
+        public int ForwardsNavigationAmount { get; set; } = 1;
+        public int BackwardsNavigationAmount { get; set; } = -1;
         #endregion
 
         #region Commands

--- a/XCalendarFormsSample/XCalendarFormsSample/ViewModels/CustomisingADayExampleViewModel.cs
+++ b/XCalendarFormsSample/XCalendarFormsSample/ViewModels/CustomisingADayExampleViewModel.cs
@@ -14,6 +14,8 @@ namespace XCalendarFormsSample.ViewModels
             SelectionAction = SelectionAction.Replace,
             SelectionType = SelectionType.Single
         };
+        public int ForwardsNavigationAmount { get; set; } = 1;
+        public int BackwardsNavigationAmount { get; set; } = -1;
         #endregion
 
         #region Commands

--- a/XCalendarFormsSample/XCalendarFormsSample/ViewModels/EventCalendarExampleViewModel.cs
+++ b/XCalendarFormsSample/XCalendarFormsSample/ViewModels/EventCalendarExampleViewModel.cs
@@ -59,6 +59,8 @@ namespace XCalendarFormsSample.ViewModels
             new Event() { Title = "Cooking", Description = "Cooking with friends" }
         };
         public ObservableRangeCollection<Event> SelectedEvents { get; } = new ObservableRangeCollection<Event>();
+        public int ForwardsNavigationAmount { get; set; } = 1;
+        public int BackwardsNavigationAmount { get; set; } = -1;
         #endregion
 
         #region Commands

--- a/XCalendarFormsSample/XCalendarFormsSample/ViewModels/PlaygroundViewModel.cs
+++ b/XCalendarFormsSample/XCalendarFormsSample/ViewModels/PlaygroundViewModel.cs
@@ -26,9 +26,7 @@ namespace XCalendarFormsSample.ViewModels
             Rows = 2,
             AutoRows = true,
             AutoRowsIsConsistent = true,
-            TodayDate = DateTime.Today,
-            ForwardsNavigationAmount = 1,
-            BackwardsNavigationAmount = -1
+            TodayDate = DateTime.Today
         };
         public bool CalendarIsVisible { get; set; } = true;
         public double DaysViewHeightRequest { get; set; } = 300;
@@ -36,6 +34,8 @@ namespace XCalendarFormsSample.ViewModels
         public double NavigationHeightRequest { get; set; } = 50;
         public double DayHeightRequest { get; set; } = 45;
         public double DayWidthRequest { get; set; } = 45;
+        public int ForwardsNavigationAmount { get; set; } = 1;
+        public int BackwardsNavigationAmount { get; set; } = -1;
         public Color CalendarBackgroundColor { get; set; } = (Color)Application.Current.Resources["CalendarBackgroundColor"];
         public Color NavigationBackgroundColor { get; set; } = (Color)Application.Current.Resources["CalendarPrimaryColor"];
         public Color NavigationTextColor { get; set; } = (Color)Application.Current.Resources["CalendarPrimaryTextColor"];

--- a/XCalendarFormsSample/XCalendarFormsSample/ViewModels/SelectionExampleViewModel.cs
+++ b/XCalendarFormsSample/XCalendarFormsSample/ViewModels/SelectionExampleViewModel.cs
@@ -25,6 +25,8 @@ namespace XCalendarFormsSample.ViewModels
             SelectionType = SelectionType.Single,
             SelectionAction = SelectionAction.Replace
         };
+        public int ForwardsNavigationAmount { get; set; } = 1;
+        public int BackwardsNavigationAmount { get; set; } = -1;
         #endregion
 
         #region Commands

--- a/XCalendarFormsSample/XCalendarFormsSample/ViewModels/SwipableCalendarExampleViewModel.cs
+++ b/XCalendarFormsSample/XCalendarFormsSample/ViewModels/SwipableCalendarExampleViewModel.cs
@@ -21,6 +21,8 @@ namespace XCalendarFormsSample.ViewModels
             }
         }
         public ObservableRangeCollection<Calendar<CalendarDay>> Calendars { get; set; } = new ObservableRangeCollection<Calendar<CalendarDay>>();
+        public int ForwardsNavigationAmount { get; set; } = 1;
+        public int BackwardsNavigationAmount { get; set; } = -1;
         #endregion
 
         #region Commands
@@ -61,8 +63,8 @@ namespace XCalendarFormsSample.ViewModels
         }
         public void UpdateCalendarPages()
         {
-            DateTime CurrentPageCalendarPreviousNavigatedDate = CurrentPageCalendar.NavigateDateTime(CurrentPageCalendar.NavigatedDate, CurrentPageCalendar.NavigationLowerBound, CurrentPageCalendar.NavigationUpperBound, CurrentPageCalendar.BackwardsNavigationAmount, CurrentPageCalendar.NavigationLoopMode, CurrentPageCalendar.NavigationTimeUnit, CurrentPageCalendar.StartOfWeek);
-            DateTime CurrentPageCalendarNextNavigatedDate = CurrentPageCalendar.NavigateDateTime(CurrentPageCalendar.NavigatedDate, CurrentPageCalendar.NavigationLowerBound, CurrentPageCalendar.NavigationUpperBound, CurrentPageCalendar.ForwardsNavigationAmount, CurrentPageCalendar.NavigationLoopMode, CurrentPageCalendar.NavigationTimeUnit, CurrentPageCalendar.StartOfWeek);
+            DateTime CurrentPageCalendarPreviousNavigatedDate = CurrentPageCalendar.NavigateDateTime(CurrentPageCalendar.NavigatedDate, CurrentPageCalendar.NavigationLowerBound, CurrentPageCalendar.NavigationUpperBound, BackwardsNavigationAmount, CurrentPageCalendar.NavigationLoopMode, CurrentPageCalendar.NavigationTimeUnit, CurrentPageCalendar.StartOfWeek);
+            DateTime CurrentPageCalendarNextNavigatedDate = CurrentPageCalendar.NavigateDateTime(CurrentPageCalendar.NavigatedDate, CurrentPageCalendar.NavigationLowerBound, CurrentPageCalendar.NavigationUpperBound, ForwardsNavigationAmount, CurrentPageCalendar.NavigationLoopMode, CurrentPageCalendar.NavigationTimeUnit, CurrentPageCalendar.StartOfWeek);
 
             if (CurrentPageCalendar == FirstPageCalendar)
             {

--- a/XCalendarFormsSample/XCalendarFormsSample/ViewModels/UsingDayViewExampleViewModel.cs
+++ b/XCalendarFormsSample/XCalendarFormsSample/ViewModels/UsingDayViewExampleViewModel.cs
@@ -15,6 +15,8 @@ namespace XCalendarFormsSample.ViewModels
             SelectionType = SelectionType.Single
         };
         public CalendarDay OutsideCalendarDay { get; set; } = new CalendarDay();
+        public int ForwardsNavigationAmount { get; set; } = 1;
+        public int BackwardsNavigationAmount { get; set; } = -1;
         #endregion
 
         #region Commands

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/CustomisingADayExamplePage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/CustomisingADayExamplePage.xaml
@@ -15,12 +15,12 @@
         <xc:CalendarView
             x:Name="MainCalendarView"
             BackwardsArrowCommand="{Binding NavigateCalendarCommand}"
-            BackwardsArrowCommandParameter="{Binding Calendar.BackwardsNavigationAmount}"
+            BackwardsArrowCommandParameter="{Binding BackwardsNavigationAmount}"
             Days="{Binding Calendar.Days}"
             DaysOfWeek="{Binding Calendar.DayNamesOrder}"
             DaysViewHeightRequest="320"
             ForwardsArrowCommand="{Binding NavigateCalendarCommand}"
-            ForwardsArrowCommandParameter="{Binding Calendar.ForwardsNavigationAmount}"
+            ForwardsArrowCommandParameter="{Binding ForwardsNavigationAmount}"
             NavigatedDate="{Binding Calendar.NavigatedDate}"
             Style="{StaticResource DefaultCalendarViewStyle}">
 

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/EventCalendarExamplePage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/EventCalendarExamplePage.xaml
@@ -45,11 +45,11 @@
             <xc:CalendarView
                 x:Name="MainCalendarView"
                 BackwardsArrowCommand="{Binding NavigateCalendarCommand}"
-                BackwardsArrowCommandParameter="{Binding EventCalendar.BackwardsNavigationAmount}"
+                BackwardsArrowCommandParameter="{Binding BackwardsNavigationAmount}"
                 Days="{Binding EventCalendar.Days}"
                 DaysOfWeek="{Binding EventCalendar.DayNamesOrder}"
                 ForwardsArrowCommand="{Binding NavigateCalendarCommand}"
-                ForwardsArrowCommandParameter="{Binding EventCalendar.ForwardsNavigationAmount}"
+                ForwardsArrowCommandParameter="{Binding ForwardsNavigationAmount}"
                 NavigatedDate="{Binding EventCalendar.NavigatedDate}"
                 Style="{StaticResource DefaultCalendarViewStyle}">
 

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/PlaygroundPage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/PlaygroundPage.xaml
@@ -254,7 +254,7 @@
                             Grid.Column="1"
                             HorizontalOptions="Center"
                             Keyboard="Numeric"
-                            Text="{Binding Calendar.ForwardsNavigationAmount}"
+                            Text="{Binding ForwardsNavigationAmount}"
                             VerticalOptions="End"/>
                     </Grid>
 
@@ -269,7 +269,7 @@
                             Grid.Column="1"
                             HorizontalOptions="Center"
                             Keyboard="Numeric"
-                            Text="{Binding Calendar.BackwardsNavigationAmount}"
+                            Text="{Binding BackwardsNavigationAmount}"
                             VerticalOptions="End"/>
                     </Grid>
 
@@ -925,13 +925,13 @@
                     x:Name="FancyCalendarView"
                     BackgroundColor="{Binding CalendarBackgroundColor}"
                     BackwardsArrowCommand="{Binding NavigateCalendarCommand}"
-                    BackwardsArrowCommandParameter="{Binding Calendar.BackwardsNavigationAmount}"
+                    BackwardsArrowCommandParameter="{Binding BackwardsNavigationAmount}"
                     DayNamesHeightRequest="{Binding DayNamesHeightRequest}"
                     Days="{Binding Calendar.Days}"
                     DaysOfWeek="{Binding Calendar.DayNamesOrder}"
                     DaysViewHeightRequest="{Binding DaysViewHeightRequest}"
                     ForwardsArrowCommand="{Binding NavigateCalendarCommand}"
-                    ForwardsArrowCommandParameter="{Binding Calendar.ForwardsNavigationAmount}"
+                    ForwardsArrowCommandParameter="{Binding ForwardsNavigationAmount}"
                     IsVisible="{Binding CalendarIsVisible}"
                     NavigatedDate="{Binding Calendar.NavigatedDate}"
                     Style="{StaticResource DefaultCalendarViewStyle}">

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/SelectionExamplePage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/SelectionExamplePage.xaml
@@ -28,11 +28,11 @@
             <xc:CalendarView
                 x:Name="MainCalendarView"
                 BackwardsArrowCommand="{Binding NavigateCalendarCommand}"
-                BackwardsArrowCommandParameter="{Binding Calendar.BackwardsNavigationAmount}"
+                BackwardsArrowCommandParameter="{Binding BackwardsNavigationAmount}"
                 Days="{Binding Calendar.Days}"
                 DaysOfWeek="{Binding Calendar.DayNamesOrder}"
                 ForwardsArrowCommand="{Binding NavigateCalendarCommand}"
-                ForwardsArrowCommandParameter="{Binding Calendar.ForwardsNavigationAmount}"
+                ForwardsArrowCommandParameter="{Binding ForwardsNavigationAmount}"
                 NavigatedDate="{Binding Calendar.NavigatedDate}"
                 Style="{StaticResource DefaultCalendarViewStyle}">
 

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/UsingDayViewExamplePage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/UsingDayViewExamplePage.xaml
@@ -16,12 +16,12 @@
             <xc:CalendarView
                 x:Name="MainCalendarView"
                 BackwardsArrowCommand="{Binding NavigateCalendarCommand}"
-                BackwardsArrowCommandParameter="{Binding Calendar.BackwardsNavigationAmount}"
+                BackwardsArrowCommandParameter="{Binding BackwardsNavigationAmount}"
                 Days="{Binding Calendar.Days}"
                 DaysOfWeek="{Binding Calendar.DayNamesOrder}"
                 DaysViewHeightRequest="330"
                 ForwardsArrowCommand="{Binding NavigateCalendarCommand}"
-                ForwardsArrowCommandParameter="{Binding Calendar.ForwardsNavigationAmount}"
+                ForwardsArrowCommandParameter="{Binding ForwardsNavigationAmount}"
                 NavigatedDate="{Binding Calendar.NavigatedDate}"
                 Style="{StaticResource DefaultCalendarViewStyle}">
 

--- a/XCalendarMauiSample/Popups/DatePickerDialogPopup.xaml
+++ b/XCalendarMauiSample/Popups/DatePickerDialogPopup.xaml
@@ -60,12 +60,12 @@
             Margin="0,5,0,0"
             Padding="20,0,20,0"
             BackwardsArrowCommand="{Binding NavigateCalendarCommand, Source={x:Reference This}}"
-            BackwardsArrowCommandParameter="{Binding Calendar.BackwardsNavigationAmount, Source={x:Reference This}}"
+            BackwardsArrowCommandParameter="{Binding BackwardsNavigationAmount, Source={x:Reference This}}"
             Days="{Binding Calendar.Days, Source={x:Reference This}}"
             DaysOfWeek="{Binding Calendar.DayNamesOrder, Source={x:Reference This}}"
             DaysViewHeightRequest="246"
             ForwardsArrowCommand="{Binding NavigateCalendarCommand, Source={x:Reference This}}"
-            ForwardsArrowCommandParameter="{Binding Calendar.ForwardsNavigationAmount, Source={x:Reference This}}"
+            ForwardsArrowCommandParameter="{Binding ForwardsNavigationAmount, Source={x:Reference This}}"
             NavigatedDate="{Binding Calendar.NavigatedDate, Source={x:Reference This}}">
 
             <xc:CalendarView.NavigationViewTemplate>

--- a/XCalendarMauiSample/Popups/DatePickerDialogPopup.xaml.cs
+++ b/XCalendarMauiSample/Popups/DatePickerDialogPopup.xaml.cs
@@ -20,6 +20,8 @@ namespace XCalendarMauiSample.Popups
             SelectionAction = SelectionAction.Replace,
             SelectionType = SelectionType.Single
         };
+        public int ForwardsNavigationAmount { get; set; } = 1;
+        public int BackwardsNavigationAmount { get; set; } = -1;
         #endregion
 
         #region Commands

--- a/XCalendarMauiSample/ViewModels/CustomisingADayExampleViewModel.cs
+++ b/XCalendarMauiSample/ViewModels/CustomisingADayExampleViewModel.cs
@@ -12,6 +12,8 @@ namespace XCalendarMauiSample.ViewModels
             SelectionAction = SelectionAction.Replace,
             SelectionType = SelectionType.Single
         };
+        public int ForwardsNavigationAmount { get; set; } = 1;
+        public int BackwardsNavigationAmount { get; set; } = -1;
         #endregion
 
         #region Commands

--- a/XCalendarMauiSample/ViewModels/EventCalendarExampleViewModel.cs
+++ b/XCalendarMauiSample/ViewModels/EventCalendarExampleViewModel.cs
@@ -55,6 +55,8 @@ namespace XCalendarMauiSample.ViewModels
             new Event() { Title = "Cooking", Description = "Cooking with friends" }
         };
         public ObservableRangeCollection<Event> SelectedEvents { get; } = new ObservableRangeCollection<Event>();
+        public int ForwardsNavigationAmount { get; set; } = 1;
+        public int BackwardsNavigationAmount { get; set; } = -1;
         #endregion
 
         #region Commands

--- a/XCalendarMauiSample/ViewModels/PlaygroundViewModel.cs
+++ b/XCalendarMauiSample/ViewModels/PlaygroundViewModel.cs
@@ -22,9 +22,7 @@ namespace XCalendarMauiSample.ViewModels
             Rows = 2,
             AutoRows = true,
             AutoRowsIsConsistent = true,
-            TodayDate = DateTime.Today,
-            ForwardsNavigationAmount = 1,
-            BackwardsNavigationAmount = -1
+            TodayDate = DateTime.Today
         };
         public bool CalendarIsVisible { get; set; } = true;
         public double DaysViewHeightRequest { get; set; } = 300;
@@ -32,6 +30,8 @@ namespace XCalendarMauiSample.ViewModels
         public double NavigationHeightRequest { get; set; } = 50;
         public double DayHeightRequest { get; set; } = 45;
         public double DayWidthRequest { get; set; } = 45;
+        public int ForwardsNavigationAmount { get; set; } = 1;
+        public int BackwardsNavigationAmount { get; set; } = -1;
         public Color CalendarBackgroundColor { get; set; } = (Color)Application.Current.Resources["CalendarBackgroundColor"];
         public Color NavigationBackgroundColor { get; set; } = (Color)Application.Current.Resources["CalendarPrimaryColor"];
         public Color NavigationTextColor { get; set; } = (Color)Application.Current.Resources["CalendarPrimaryTextColor"];

--- a/XCalendarMauiSample/ViewModels/SelectionExampleViewModel.cs
+++ b/XCalendarMauiSample/ViewModels/SelectionExampleViewModel.cs
@@ -22,6 +22,8 @@ namespace XCalendarMauiSample.ViewModels
             SelectionType = SelectionType.Single,
             SelectionAction = SelectionAction.Replace
         };
+        public int ForwardsNavigationAmount { get; set; } = 1;
+        public int BackwardsNavigationAmount { get; set; } = -1;
         #endregion
 
         #region Commands

--- a/XCalendarMauiSample/ViewModels/SwipableCalendarExampleViewModel.cs
+++ b/XCalendarMauiSample/ViewModels/SwipableCalendarExampleViewModel.cs
@@ -19,6 +19,8 @@ namespace XCalendarMauiSample.ViewModels
             }
         }
         public ObservableRangeCollection<Calendar<CalendarDay>> Calendars { get; set; } = new ObservableRangeCollection<Calendar<CalendarDay>>();
+        public int ForwardsNavigationAmount { get; set; } = 1;
+        public int BackwardsNavigationAmount { get; set; } = -1;
         #endregion
 
         #region Commands
@@ -59,8 +61,8 @@ namespace XCalendarMauiSample.ViewModels
         }
         public void UpdateCalendarPages()
         {
-            DateTime CurrentPageCalendarPreviousNavigatedDate = CurrentPageCalendar.NavigateDateTime(CurrentPageCalendar.NavigatedDate, CurrentPageCalendar.NavigationLowerBound, CurrentPageCalendar.NavigationUpperBound, CurrentPageCalendar.BackwardsNavigationAmount, CurrentPageCalendar.NavigationLoopMode, CurrentPageCalendar.NavigationTimeUnit, CurrentPageCalendar.StartOfWeek);
-            DateTime CurrentPageCalendarNextNavigatedDate = CurrentPageCalendar.NavigateDateTime(CurrentPageCalendar.NavigatedDate, CurrentPageCalendar.NavigationLowerBound, CurrentPageCalendar.NavigationUpperBound, CurrentPageCalendar.ForwardsNavigationAmount, CurrentPageCalendar.NavigationLoopMode, CurrentPageCalendar.NavigationTimeUnit, CurrentPageCalendar.StartOfWeek);
+            DateTime CurrentPageCalendarPreviousNavigatedDate = CurrentPageCalendar.NavigateDateTime(CurrentPageCalendar.NavigatedDate, CurrentPageCalendar.NavigationLowerBound, CurrentPageCalendar.NavigationUpperBound, BackwardsNavigationAmount, CurrentPageCalendar.NavigationLoopMode, CurrentPageCalendar.NavigationTimeUnit, CurrentPageCalendar.StartOfWeek);
+            DateTime CurrentPageCalendarNextNavigatedDate = CurrentPageCalendar.NavigateDateTime(CurrentPageCalendar.NavigatedDate, CurrentPageCalendar.NavigationLowerBound, CurrentPageCalendar.NavigationUpperBound, ForwardsNavigationAmount, CurrentPageCalendar.NavigationLoopMode, CurrentPageCalendar.NavigationTimeUnit, CurrentPageCalendar.StartOfWeek);
 
             if (CurrentPageCalendar == FirstPageCalendar)
             {

--- a/XCalendarMauiSample/ViewModels/UsingDayViewExampleViewModel.cs
+++ b/XCalendarMauiSample/ViewModels/UsingDayViewExampleViewModel.cs
@@ -13,6 +13,8 @@ namespace XCalendarMauiSample.ViewModels
             SelectionType = SelectionType.Single
         };
         public CalendarDay OutsideCalendarDay { get; set; } = new CalendarDay();
+        public int ForwardsNavigationAmount { get; set; } = 1;
+        public int BackwardsNavigationAmount { get; set; } = -1;
         #endregion
 
         #region Commands

--- a/XCalendarMauiSample/Views/CustomisingADayExamplePage.xaml
+++ b/XCalendarMauiSample/Views/CustomisingADayExamplePage.xaml
@@ -15,12 +15,12 @@
         <xc:CalendarView
             x:Name="MainCalendarView"
             BackwardsArrowCommand="{Binding NavigateCalendarCommand}"
-            BackwardsArrowCommandParameter="{Binding Calendar.BackwardsNavigationAmount}"
+            BackwardsArrowCommandParameter="{Binding BackwardsNavigationAmount}"
             Days="{Binding Calendar.Days}"
             DaysOfWeek="{Binding Calendar.DayNamesOrder}"
             DaysViewHeightRequest="320"
             ForwardsArrowCommand="{Binding NavigateCalendarCommand}"
-            ForwardsArrowCommandParameter="{Binding Calendar.ForwardsNavigationAmount}"
+            ForwardsArrowCommandParameter="{Binding ForwardsNavigationAmount}"
             NavigatedDate="{Binding Calendar.NavigatedDate}"
             Style="{StaticResource DefaultCalendarViewStyle}">
 

--- a/XCalendarMauiSample/Views/EventCalendarExamplePage.xaml
+++ b/XCalendarMauiSample/Views/EventCalendarExamplePage.xaml
@@ -46,11 +46,11 @@
             <xc:CalendarView
                 x:Name="MainCalendarView"
                 BackwardsArrowCommand="{Binding NavigateCalendarCommand}"
-                BackwardsArrowCommandParameter="{Binding EventCalendar.BackwardsNavigationAmount}"
+                BackwardsArrowCommandParameter="{Binding BackwardsNavigationAmount}"
                 Days="{Binding EventCalendar.Days}"
                 DaysOfWeek="{Binding EventCalendar.DayNamesOrder}"
                 ForwardsArrowCommand="{Binding NavigateCalendarCommand}"
-                ForwardsArrowCommandParameter="{Binding EventCalendar.ForwardsNavigationAmount}"
+                ForwardsArrowCommandParameter="{Binding ForwardsNavigationAmount}"
                 NavigatedDate="{Binding EventCalendar.NavigatedDate}"
                 Style="{StaticResource DefaultCalendarViewStyle}">
 

--- a/XCalendarMauiSample/Views/PlaygroundPage.xaml
+++ b/XCalendarMauiSample/Views/PlaygroundPage.xaml
@@ -251,7 +251,7 @@
                         Grid.Column="1"
                         HorizontalOptions="Center"
                         Keyboard="Numeric"
-                        Text="{Binding Calendar.ForwardsNavigationAmount}"
+                        Text="{Binding ForwardsNavigationAmount}"
                         VerticalOptions="End"/>
                 </Grid>
 
@@ -266,7 +266,7 @@
                         Grid.Column="1"
                         HorizontalOptions="Center"
                         Keyboard="Numeric"
-                        Text="{Binding Calendar.BackwardsNavigationAmount}"
+                        Text="{Binding BackwardsNavigationAmount}"
                         VerticalOptions="End"/>
                 </Grid>
 
@@ -967,13 +967,13 @@
                 x:Name="FancyCalendarView"
                 BackgroundColor="{Binding CalendarBackgroundColor}"
                 BackwardsArrowCommand="{Binding NavigateCalendarCommand}"
-                BackwardsArrowCommandParameter="{Binding Calendar.BackwardsNavigationAmount}"
+                BackwardsArrowCommandParameter="{Binding BackwardsNavigationAmount}"
                 DayNamesHeightRequest="{Binding DayNamesHeightRequest}"
                 Days="{Binding Calendar.Days}"
                 DaysOfWeek="{Binding Calendar.DayNamesOrder}"
                 DaysViewHeightRequest="{Binding DaysViewHeightRequest}"
                 ForwardsArrowCommand="{Binding NavigateCalendarCommand}"
-                ForwardsArrowCommandParameter="{Binding Calendar.ForwardsNavigationAmount}"
+                ForwardsArrowCommandParameter="{Binding ForwardsNavigationAmount}"
                 IsVisible="{Binding CalendarIsVisible}"
                 NavigatedDate="{Binding Calendar.NavigatedDate}"
                 Style="{StaticResource DefaultCalendarViewStyle}">

--- a/XCalendarMauiSample/Views/SelectionExamplePage.xaml
+++ b/XCalendarMauiSample/Views/SelectionExamplePage.xaml
@@ -29,11 +29,11 @@
             <xc:CalendarView
                 x:Name="MainCalendarView"
                 BackwardsArrowCommand="{Binding NavigateCalendarCommand}"
-                BackwardsArrowCommandParameter="{Binding Calendar.BackwardsNavigationAmount}"
+                BackwardsArrowCommandParameter="{Binding BackwardsNavigationAmount}"
                 Days="{Binding Calendar.Days}"
                 DaysOfWeek="{Binding Calendar.DayNamesOrder}"
                 ForwardsArrowCommand="{Binding NavigateCalendarCommand}"
-                ForwardsArrowCommandParameter="{Binding Calendar.ForwardsNavigationAmount}"
+                ForwardsArrowCommandParameter="{Binding ForwardsNavigationAmount}"
                 NavigatedDate="{Binding Calendar.NavigatedDate}"
                 Style="{StaticResource DefaultCalendarViewStyle}">
 

--- a/XCalendarMauiSample/Views/UsingDayViewExamplePage.xaml
+++ b/XCalendarMauiSample/Views/UsingDayViewExamplePage.xaml
@@ -16,12 +16,12 @@
             <xc:CalendarView
                 x:Name="MainCalendarView"
                 BackwardsArrowCommand="{Binding NavigateCalendarCommand}"
-                BackwardsArrowCommandParameter="{Binding Calendar.BackwardsNavigationAmount}"
+                BackwardsArrowCommandParameter="{Binding BackwardsNavigationAmount}"
                 Days="{Binding Calendar.Days}"
                 DaysOfWeek="{Binding Calendar.DayNamesOrder}"
                 DaysViewHeightRequest="330"
                 ForwardsArrowCommand="{Binding NavigateCalendarCommand}"
-                ForwardsArrowCommandParameter="{Binding Calendar.ForwardsNavigationAmount}"
+                ForwardsArrowCommandParameter="{Binding ForwardsNavigationAmount}"
                 NavigatedDate="{Binding Calendar.NavigatedDate}"
                 Style="{StaticResource DefaultCalendarViewStyle}">
 


### PR DESCRIPTION
The 'NavigateCalendar' method uses the value from the 'Amount' parameter instead of using these properties. The developer has the option of using a variable that can be outside the Calendar. Since these properties aren't used anywhere and just act as optional variables to use, they aren't actually needed.