### PR TITLE
Remove dependency on 'CommunityToolkit.MAUI' nuget package in XCalendar.Maui

### DIFF
--- a/XCalendar.Forms/Converters/StringCharLimitConverter.cs
+++ b/XCalendar.Forms/Converters/StringCharLimitConverter.cs
@@ -31,10 +31,9 @@ namespace XCalendar.Forms.Converters
                 return "";
             }
         }
-
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/XCalendar.Maui/Converters/IsNullOrEmptyConverter.cs
+++ b/XCalendar.Maui/Converters/IsNullOrEmptyConverter.cs
@@ -1,0 +1,17 @@
+﻿using System.Globalization;
+
+namespace XCalendar.Maui.Converters
+{
+    public class IsNullOrEmptyConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value == null || (value is string stringValue && string.IsNullOrWhiteSpace(stringValue));
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/XCalendar.Maui/Converters/StringCharLimitConverter.cs
+++ b/XCalendar.Maui/Converters/StringCharLimitConverter.cs
@@ -1,28 +1,15 @@
-﻿using CommunityToolkit.Maui.Converters;
-using System.Globalization;
+﻿using System.Globalization;
 
 namespace XCalendar.Maui.Converters
 {
-    public class StringCharLimitConverter : BaseConverterOneWay<object, string, object>
+    public class StringCharLimitConverter : IValueConverter
     {
-        private string _defaultConvertReturnValue = "";
-        public override string DefaultConvertReturnValue
-        {
-            get
-            {
-                return _defaultConvertReturnValue;
-            }
-            set
-            {
-                _defaultConvertReturnValue = value;
-            }
-        }
-        public override string ConvertFrom(object value, object parameter, CultureInfo culture)
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             try
             {
                 string stringValue = value.ToString();
-                int targetLength = Convert.ToInt32(parameter);
+                int targetLength = System.Convert.ToInt32(parameter);
 
                 if (targetLength == 0)
                 {
@@ -39,8 +26,12 @@ namespace XCalendar.Maui.Converters
             }
             catch
             {
-                return DefaultConvertReturnValue;
+                return "";
             }
+        }
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
         }
     }
 }

--- a/XCalendar.Maui/Views/CalendarView.xaml
+++ b/XCalendar.Maui/Views/CalendarView.xaml
@@ -6,7 +6,6 @@
     xmlns:Converters="clr-namespace:XCalendar.Maui.Converters"
     xmlns:Models="clr-namespace:XCalendar.Core.Models;assembly=XCalendar.Core"
     xmlns:System="clr-namespace:System;assembly=mscorlib"
-    xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
     xmlns:xc="clr-namespace:XCalendar.Maui.Views"
     xmlns:xcInterfaces="clr-namespace:XCalendar.Core.Interfaces;assembly=XCalendar.Core"
     x:Name="CalendarView_Unique"
@@ -14,13 +13,9 @@
 
     <VerticalStackLayout Spacing="0">
         <VerticalStackLayout.Resources>
-            <System:Boolean x:Key="TrueValue">True</System:Boolean>
             <System:Boolean x:Key="FalseValue">False</System:Boolean>
 
-            <mct:IsNotEqualConverter x:Key="IsNotEqualConverter"/>
-
-            <mct:MathExpressionConverter x:Key="MathExpressionConverter"/>
-
+            <Converters:IsNullOrEmptyConverter x:Key="IsNullOrEmptyConverter"/>
             <Converters:StringCharLimitConverter x:Key="StringCharLimitConverter"/>
         </VerticalStackLayout.Resources>
 
@@ -56,9 +51,9 @@
 
                         <Style.Triggers>
                             <DataTrigger
-                                Binding="{Binding DayNameTemplate, Source={x:Reference CalendarView_Unique}, Converter={StaticResource IsNotEqualConverter}, ConverterParameter={x:Null}}"
+                                Binding="{Binding DayNameTemplate, Source={x:Reference CalendarView_Unique}, Converter={StaticResource IsNullOrEmptyConverter}}"
                                 TargetType="{x:Type CollectionView}"
-                                Value="{StaticResource TrueValue}">
+                                Value="{StaticResource FalseValue}">
                                 <Setter Property="ItemTemplate" Value="{Binding DayNameTemplate, Source={x:Reference CalendarView_Unique}}"/>
                             </DataTrigger>
                         </Style.Triggers>

--- a/XCalendar.Maui/Views/DaysView.xaml
+++ b/XCalendar.Maui/Views/DaysView.xaml
@@ -5,7 +5,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:Converters="clr-namespace:XCalendar.Maui.Converters"
     xmlns:System="clr-namespace:System;assembly=mscorlib"
-    xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
     xmlns:xc="clr-namespace:XCalendar.Maui.Views"
     xmlns:xcInterfaces="clr-namespace:XCalendar.Core.Interfaces;assembly=XCalendar.Core"
     x:Name="DaysView_Unique"
@@ -14,9 +13,9 @@
     <CollectionView x:Name="MainCollectionView">
 
         <CollectionView.Resources>
-            <System:Boolean x:Key="TrueValue">True</System:Boolean>
+            <System:Boolean x:Key="FalseValue">False</System:Boolean>
 
-            <mct:IsNotEqualConverter x:Key="IsNotEqualConverter"/>
+            <Converters:IsNullOrEmptyConverter x:Key="IsNullOrEmptyConverter"/>
         </CollectionView.Resources>
 
         <CollectionView.Style>
@@ -47,9 +46,9 @@
 
                 <Style.Triggers>
                     <DataTrigger
-                        Binding="{Binding DayTemplate, Source={x:Reference DaysView_Unique}, Converter={StaticResource IsNotEqualConverter}, ConverterParameter={x:Null}}"
+                        Binding="{Binding DayTemplate, Source={x:Reference DaysView_Unique}, Converter={StaticResource IsNullOrEmptyConverter}}"
                         TargetType="{x:Type CollectionView}"
-                        Value="{StaticResource TrueValue}">
+                        Value="{StaticResource FalseValue}">
                         <Setter Property="ItemTemplate" Value="{Binding DayTemplate, Source={x:Reference DaysView_Unique}}"/>
                     </DataTrigger>
                 </Style.Triggers>

--- a/XCalendar.Maui/XCalendar.Maui.csproj
+++ b/XCalendar.Maui/XCalendar.Maui.csproj
@@ -41,10 +41,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="CommunityToolkit.Maui" Version="3.0.0" />
-	</ItemGroup>
-
-	<ItemGroup>
 	  <ProjectReference Include="..\XCalendar.Core\XCalendar.Core.csproj" />
 	</ItemGroup>
 

--- a/XCalendarMauiSample/XCalendarMauiSample.csproj
+++ b/XCalendarMauiSample/XCalendarMauiSample.csproj
@@ -61,6 +61,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <PackageReference Include="CommunityToolkit.Maui" Version="3.1.0" />
 	  <PackageReference Include="PropertyChanged.Fody" Version="4.0.4" />
 	</ItemGroup>
 


### PR DESCRIPTION
CommunityToolkit.Maui 3.1.0 was used in XCalendarMauiSample because 4.0.0 causes a MissingFieldException on startup on an Android 10 device.

Full exception: "system.missingfieldexception: 'field not found: int .animation.linear_indeterminate_line1_head_interpolator due to: could not find field in class'"