### PR TITLE
Add a non-generic type for class "Calendar"

### DIFF
--- a/XCalendar.Core/Models/Calendar.cs
+++ b/XCalendar.Core/Models/Calendar.cs
@@ -17,6 +17,9 @@ namespace XCalendar.Core.Models
     /// A class to represent a calendar.
     /// </summary>
     /// <typeparam name="T">A model implementing <see cref="ICalendarDay"/> to be used to represent each day in a page.</typeparam>
+    public class Calendar : Calendar<CalendarDay>
+    {
+    }
     public class Calendar<T> : ICalendar<T> where T : ICalendarDay, new()
     {
         #region Fields

--- a/XCalendar.Core/Models/Calendar.cs
+++ b/XCalendar.Core/Models/Calendar.cs
@@ -14,12 +14,15 @@ using XCalendar.Core.Interfaces;
 namespace XCalendar.Core.Models
 {
     /// <summary>
-    /// A class to represent a calendar.
+    /// A class representing a calendar.
     /// </summary>
-    /// <typeparam name="T">A model implementing <see cref="ICalendarDay"/> to be used to represent each day in a page.</typeparam>
     public class Calendar : Calendar<CalendarDay>
     {
     }
+    /// <summary>
+    /// A class representing a calendar.
+    /// </summary>
+    /// <typeparam name="T">A model implementing <see cref="ICalendarDay"/> to be used to represent each day in a page.</typeparam>
     public class Calendar<T> : ICalendar<T> where T : ICalendarDay, new()
     {
         #region Fields


### PR DESCRIPTION
If you just want to use the default implementation of the Calendar, you shouldn't have to specify a type parameter.