### PR TITLE
Change DayView to use styles for each `DayState` it can be in instead of using specific customisation properties

### DIFF
--- a/XCalendar.Forms/Styles/DefaultStyles.cs
+++ b/XCalendar.Forms/Styles/DefaultStyles.cs
@@ -1,0 +1,59 @@
+﻿using Xamarin.Forms;
+using XCalendar.Forms.Views;
+
+namespace XCalendar.Forms.Styles
+{
+    public static class DefaultStyles
+    {
+        #region Properties
+        public static Style DefaultDayViewCurrentMonthStyle { get; } = CreateDefaultDayViewCurrentMonthStyle();
+        public static Style DefaultDayViewOtherMonthStyle { get; } = CreateDefaultDayViewOtherMonthStyle();
+        public static Style DefaultDayViewTodayStyle { get; } = CreateDefaultDayViewTodayStyle();
+        public static Style DefaultDayViewSelectedStyle { get; } = CreateDefaultDayViewSelectedStyle();
+        public static Style DefaultDayViewInvalidStyle { get; } = CreateDefaultDayViewInvalidStyle();
+        #endregion
+
+        #region Methods
+        public static Style CreateDefaultDayViewCurrentMonthStyle()
+        {
+            Style style = new Style(typeof(DayView)) { CanCascade = true };
+            style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Color.Transparent });
+            style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Color.Black });
+
+            return style;
+        }
+        public static Style CreateDefaultDayViewOtherMonthStyle()
+        {
+            Style style = new Style(typeof(DayView)) { CanCascade = true };
+            style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Color.Transparent });
+            style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Color.FromHex("#A0A0A0") });
+
+            return style;
+        }
+        public static Style CreateDefaultDayViewTodayStyle()
+        {
+            Style style = new Style(typeof(DayView)) { CanCascade = true };
+            style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Color.Transparent });
+            style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Color.Black });
+
+            return style;
+        }
+        public static Style CreateDefaultDayViewSelectedStyle()
+        {
+            Style style = new Style(typeof(DayView)) { CanCascade = true };
+            style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Color.FromHex("#E00000") });
+            style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Color.Black });
+
+            return style;
+        }
+        public static Style CreateDefaultDayViewInvalidStyle()
+        {
+            Style style = new Style(typeof(DayView)) { CanCascade = true };
+            style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Color.Transparent });
+            style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Color.FromHex("#FFA0A0") });
+
+            return style;
+        }
+        #endregion
+    }
+}

--- a/XCalendar.Forms/Views/DayView.xaml.cs
+++ b/XCalendar.Forms/Views/DayView.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows.Input;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 using XCalendar.Core.Enums;
+using XCalendar.Forms.Styles;
 
 namespace XCalendar.Forms.Views
 {
@@ -72,105 +73,30 @@ namespace XCalendar.Forms.Views
             get { return (bool)GetValue(IsDayStateInvalidProperty); }
             set { SetValue(IsDayStateInvalidProperty, value); }
         }
-        public Color CurrentMonthTextColor
+        public Style CurrentMonthStyle
         {
-            get { return (Color)GetValue(CurrentMonthTextColorProperty); }
-            set { SetValue(CurrentMonthTextColorProperty, value); }
+            get { return (Style)GetValue(CurrentMonthStyleProperty); }
+            set { SetValue(CurrentMonthStyleProperty, value); }
         }
-        public Color CurrentMonthBackgroundColor
+        public Style TodayStyle
         {
-            get { return (Color)GetValue(CurrentMonthBackgroundColorProperty); }
-            set { SetValue(CurrentMonthBackgroundColorProperty, value); }
+            get { return (Style)GetValue(TodayStyleProperty); }
+            set { SetValue(TodayStyleProperty, value); }
         }
-        public ICommand CurrentMonthCommand
+        public Style OtherMonthStyle
         {
-            get { return (ICommand)GetValue(CurrentMonthCommandProperty); }
-            set { SetValue(CurrentMonthCommandProperty, value); }
+            get { return (Style)GetValue(OtherMonthStyleProperty); }
+            set { SetValue(OtherMonthStyleProperty, value); }
         }
-        public object CurrentMonthCommandParameter
+        public Style InvalidStyle
         {
-            get { return (object)GetValue(CurrentMonthCommandParameterProperty); }
-            set { SetValue(CurrentMonthCommandParameterProperty, value); }
+            get { return (Style)GetValue(InvalidStyleProperty); }
+            set { SetValue(InvalidStyleProperty, value); }
         }
-        public Color TodayTextColor
+        public Style SelectedStyle
         {
-            get { return (Color)GetValue(TodayTextColorProperty); }
-            set { SetValue(TodayTextColorProperty, value); }
-        }
-        public Color TodayBackgroundColor
-        {
-            get { return (Color)GetValue(TodayBackgroundColorProperty); }
-            set { SetValue(TodayBackgroundColorProperty, value); }
-        }
-        public ICommand TodayCommand
-        {
-            get { return (ICommand)GetValue(TodayCommandProperty); }
-            set { SetValue(TodayCommandProperty, value); }
-        }
-        public object TodayCommandParameter
-        {
-            get { return (object)GetValue(TodayCommandParameterProperty); }
-            set { SetValue(TodayCommandParameterProperty, value); }
-        }
-        public Color OtherMonthTextColor
-        {
-            get { return (Color)GetValue(OtherMonthTextColorProperty); }
-            set { SetValue(OtherMonthTextColorProperty, value); }
-        }
-        public Color OtherMonthBackgroundColor
-        {
-            get { return (Color)GetValue(OtherMonthBackgroundColorProperty); }
-            set { SetValue(OtherMonthBackgroundColorProperty, value); }
-        }
-        public ICommand OtherMonthCommand
-        {
-            get { return (ICommand)GetValue(OtherMonthCommandProperty); }
-            set { SetValue(OtherMonthCommandProperty, value); }
-        }
-        public object OtherMonthCommandParameter
-        {
-            get { return (object)GetValue(OtherMonthCommandParameterProperty); }
-            set { SetValue(OtherMonthCommandParameterProperty, value); }
-        }
-        public Color InvalidTextColor
-        {
-            get { return (Color)GetValue(InvalidTextColorProperty); }
-            set { SetValue(InvalidTextColorProperty, value); }
-        }
-        public Color InvalidBackgroundColor
-        {
-            get { return (Color)GetValue(InvalidBackgroundColorProperty); }
-            set { SetValue(InvalidBackgroundColorProperty, value); }
-        }
-        public ICommand InvalidCommand
-        {
-            get { return (ICommand)GetValue(InvalidCommandProperty); }
-            set { SetValue(InvalidCommandProperty, value); }
-        }
-        public object InvalidCommandParameter
-        {
-            get { return (object)GetValue(InvalidCommandParameterProperty); }
-            set { SetValue(InvalidCommandParameterProperty, value); }
-        }
-        public Color SelectedTextColor
-        {
-            get { return (Color)GetValue(SelectedTextColorProperty); }
-            set { SetValue(SelectedTextColorProperty, value); }
-        }
-        public Color SelectedBackgroundColor
-        {
-            get { return (Color)GetValue(SelectedBackgroundColorProperty); }
-            set { SetValue(SelectedBackgroundColorProperty, value); }
-        }
-        public ICommand SelectedCommand
-        {
-            get { return (ICommand)GetValue(SelectedCommandProperty); }
-            set { SetValue(SelectedCommandProperty, value); }
-        }
-        public object SelectedCommandParameter
-        {
-            get { return (object)GetValue(SelectedCommandParameterProperty); }
-            set { SetValue(SelectedCommandParameterProperty, value); }
+            get { return (Style)GetValue(SelectedStyleProperty); }
+            set { SetValue(SelectedStyleProperty, value); }
         }
         public ICommand Command
         {
@@ -262,7 +188,7 @@ namespace XCalendar.Forms.Views
 
         #region Bindable Properties Initialisers
         public static readonly BindableProperty DateTimeProperty = BindableProperty.Create(nameof(DateTime), typeof(DateTime?), typeof(DayView), System.DateTime.Today, propertyChanged: DateTimePropertyChanged);
-        public static readonly BindableProperty DayStateProperty = BindableProperty.Create(nameof(DayState), typeof(DayState), typeof(DayView), propertyChanged: DayStatePropertyChanged, coerceValue: CoerceDayState);
+        public static readonly BindableProperty DayStateProperty = BindableProperty.Create(nameof(DayState), typeof(DayState), typeof(DayView), DayState.CurrentMonth, propertyChanged: DayStatePropertyChanged, coerceValue: CoerceDayState);
         public static readonly BindableProperty IsCurrentMonthProperty = BindableProperty.Create(nameof(IsCurrentMonth), typeof(bool), typeof(DayView), true, propertyChanged: IsCurrentMonthPropertyChanged);
         public static readonly BindableProperty IsOtherMonthProperty = BindableProperty.Create(nameof(IsOtherMonth), typeof(bool), typeof(DayView), propertyChanged: IsOtherMonthPropertyChanged);
         public static readonly BindableProperty IsTodayProperty = BindableProperty.Create(nameof(IsToday), typeof(bool), typeof(DayView), propertyChanged: IsTodayPropertyChanged);
@@ -273,26 +199,11 @@ namespace XCalendar.Forms.Views
         public static readonly BindableProperty IsDayStateTodayProperty = BindableProperty.Create(nameof(IsDayStateToday), typeof(bool), typeof(DayView));
         public static readonly BindableProperty IsDayStateSelectedProperty = BindableProperty.Create(nameof(IsDayStateSelected), typeof(bool), typeof(DayView));
         public static readonly BindableProperty IsDayStateInvalidProperty = BindableProperty.Create(nameof(IsDayStateInvalid), typeof(bool), typeof(DayView));
-        public static readonly BindableProperty CurrentMonthTextColorProperty = BindableProperty.Create(nameof(CurrentMonthTextColor), typeof(Color), typeof(DayView), Color.Black, propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty CurrentMonthBackgroundColorProperty = BindableProperty.Create(nameof(CurrentMonthBackgroundColor), typeof(Color), typeof(DayView), Color.Transparent, propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty CurrentMonthCommandProperty = BindableProperty.Create(nameof(CurrentMonthCommand), typeof(ICommand), typeof(DayView), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty CurrentMonthCommandParameterProperty = BindableProperty.Create(nameof(CurrentMonthCommandParameter), typeof(object), typeof(DayView), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty TodayTextColorProperty = BindableProperty.Create(nameof(TodayTextColor), typeof(Color), typeof(DayView), Color.Black, propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty TodayBackgroundColorProperty = BindableProperty.Create(nameof(TodayBackgroundColor), typeof(Color), typeof(DayView), Color.Transparent, propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty TodayCommandProperty = BindableProperty.Create(nameof(TodayCommand), typeof(ICommand), typeof(DayView), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty TodayCommandParameterProperty = BindableProperty.Create(nameof(TodayCommandParameter), typeof(object), typeof(DayView), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty OtherMonthTextColorProperty = BindableProperty.Create(nameof(OtherMonthTextColor), typeof(Color), typeof(DayView), Color.FromHex("#A0A0A0"), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty OtherMonthBackgroundColorProperty = BindableProperty.Create(nameof(OtherMonthBackgroundColor), typeof(Color), typeof(DayView), Color.Transparent, propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty OtherMonthCommandProperty = BindableProperty.Create(nameof(OtherMonthCommand), typeof(ICommand), typeof(DayView), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty OtherMonthCommandParameterProperty = BindableProperty.Create(nameof(OtherMonthCommandParameter), typeof(object), typeof(DayView), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty InvalidTextColorProperty = BindableProperty.Create(nameof(InvalidTextColor), typeof(Color), typeof(DayView), Color.FromHex("#FFA0A0"), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty InvalidBackgroundColorProperty = BindableProperty.Create(nameof(InvalidBackgroundColor), typeof(Color), typeof(DayView), Color.Transparent, propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty InvalidCommandProperty = BindableProperty.Create(nameof(InvalidCommand), typeof(ICommand), typeof(DayView), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty InvalidCommandParameterProperty = BindableProperty.Create(nameof(InvalidCommandParameter), typeof(object), typeof(DayView), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty SelectedTextColorProperty = BindableProperty.Create(nameof(SelectedTextColor), typeof(Color), typeof(DayView), Color.White, propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty SelectedBackgroundColorProperty = BindableProperty.Create(nameof(SelectedBackgroundColor), typeof(Color), typeof(DayView), Color.FromHex("#E00000"), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty SelectedCommandProperty = BindableProperty.Create(nameof(SelectedCommand), typeof(ICommand), typeof(DayView), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty SelectedCommandParameterProperty = BindableProperty.Create(nameof(SelectedCommandParameter), typeof(object), typeof(DayView), propertyChanged: StateAppearanceChanged);
+        public static readonly BindableProperty CurrentMonthStyleProperty = BindableProperty.Create(nameof(CurrentMonthStyle), typeof(Style), typeof(DayView), propertyChanged: CurrentMonthStylePropertyChanged, defaultValueCreator: CreateDefaultDayViewCurrentMonthStyle);
+        public static readonly BindableProperty OtherMonthStyleProperty = BindableProperty.Create(nameof(OtherMonthStyle), typeof(Style), typeof(DayView), propertyChanged: OtherMonthStylePropertyChanged, defaultValueCreator: CreateDefaultDayViewOtherMonthStyle);
+        public static readonly BindableProperty TodayStyleProperty = BindableProperty.Create(nameof(TodayStyle), typeof(Style), typeof(DayView), propertyChanged: TodayStylePropertyChanged, defaultValueCreator: CreateDefaultDayViewTodayStyle);
+        public static readonly BindableProperty SelectedStyleProperty = BindableProperty.Create(nameof(SelectedStyle), typeof(Style), typeof(DayView), propertyChanged: SelectedStylePropertyChanged, defaultValueCreator: CreateDefaultDayViewSelectedStyle);
+        public static readonly BindableProperty InvalidStyleProperty = BindableProperty.Create(nameof(InvalidStyle), typeof(Style), typeof(DayView), propertyChanged: InvalidStylePropertyChanged, defaultValueCreator: CreateDefaultDayViewInvalidStyle);
         public static readonly BindableProperty CommandProperty = BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(DayView));
         public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(DayView));
         public static readonly BindableProperty CharacterSpacingProperty = BindableProperty.Create(nameof(CharacterSpacing), typeof(double), typeof(DayView), Label.CharacterSpacingProperty.DefaultValue);
@@ -318,7 +229,6 @@ namespace XCalendar.Forms.Views
         public DayView()
         {
             SetBinding(TextProperty, new Binding(path: "DateTime.Day", source: this));
-            DayState = DayState.CurrentMonth;
 
             InitializeComponent();
         }
@@ -359,39 +269,23 @@ namespace XCalendar.Forms.Views
             switch (DayState)
             {
                 case DayState.CurrentMonth:
-                    BackgroundColor = CurrentMonthBackgroundColor;
-                    TextColor = CurrentMonthTextColor;
-                    Command = CurrentMonthCommand;
-                    CommandParameter = CurrentMonthCommandParameter;
+                    Style = CurrentMonthStyle;
                     break;
 
                 case DayState.OtherMonth:
-                    BackgroundColor = OtherMonthBackgroundColor;
-                    TextColor = OtherMonthTextColor;
-                    Command = OtherMonthCommand;
-                    CommandParameter = OtherMonthCommandParameter;
+                    Style = OtherMonthStyle;
                     break;
 
                 case DayState.Today:
-                    BackgroundColor = TodayBackgroundColor;
-                    TextColor = TodayTextColor;
-                    Command = TodayCommand;
-                    CommandParameter = TodayCommandParameter;
+                    Style = TodayStyle;
                     break;
 
                 case DayState.Selected:
-                    BackgroundColor = SelectedBackgroundColor;
-                    TextColor = SelectedTextColor;
-                    Command = SelectedCommand;
-                    CommandParameter = SelectedCommandParameter;
+                    Style = SelectedStyle;
                     break;
 
                 case DayState.Invalid:
-                    BackgroundColor = InvalidBackgroundColor;
-                    TextColor = InvalidTextColor;
-                    Command = InvalidCommand;
-                    CommandParameter = InvalidCommandParameter;
-
+                    Style = InvalidStyle;
                     break;
 
                 default:
@@ -400,47 +294,66 @@ namespace XCalendar.Forms.Views
         }
 
         #region Bindable Properties Methods
+        private static object CreateDefaultDayViewCurrentMonthStyle(BindableObject bindable)
+        {
+            //Default value doesn't work so a DefaultValueCreator is used instead.
+            return DefaultStyles.DefaultDayViewCurrentMonthStyle;
+        }
+        private static object CreateDefaultDayViewOtherMonthStyle(BindableObject bindable)
+        {
+            //Default value doesn't work so a DefaultValueCreator is used instead.
+            return DefaultStyles.DefaultDayViewOtherMonthStyle;
+        }
+        private static object CreateDefaultDayViewTodayStyle(BindableObject bindable)
+        {
+            //Default value doesn't work so a DefaultValueCreator is used instead.
+            return DefaultStyles.DefaultDayViewTodayStyle;
+        }
+        private static object CreateDefaultDayViewSelectedStyle(BindableObject bindable)
+        {
+            //Default value doesn't work so a DefaultValueCreator is used instead.
+            return DefaultStyles.DefaultDayViewSelectedStyle;
+        }
+        private static object CreateDefaultDayViewInvalidStyle(BindableObject bindable)
+        {
+            //Default value doesn't work so a DefaultValueCreator is used instead.
+            return DefaultStyles.DefaultDayViewInvalidStyle;
+        }
         private static void DateTimePropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             DayView control = (DayView)bindable;
 
             control.DayState = control.EvaluateDayState();
-            control.UpdateView();
         }
         private static void IsCurrentMonthPropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             DayView control = (DayView)bindable;
 
             control.DayState = control.EvaluateDayState();
-            control.UpdateView();
         }
         private static void IsOtherMonthPropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             DayView control = (DayView)bindable;
 
             control.DayState = control.EvaluateDayState();
-            control.UpdateView();
         }
         private static void IsTodayPropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             DayView control = (DayView)bindable;
 
             control.DayState = control.EvaluateDayState();
-            control.UpdateView();
         }
         private static void IsSelectedPropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             DayView control = (DayView)bindable;
 
             control.DayState = control.EvaluateDayState();
-            control.UpdateView();
         }
         private static void IsInvalidPropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             DayView control = (DayView)bindable;
 
             control.DayState = control.EvaluateDayState();
-            control.UpdateView();
         }
         private static void DayStatePropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
@@ -452,14 +365,44 @@ namespace XCalendar.Forms.Views
             control.IsDayStateToday = newDayState == DayState.Today;
             control.IsDayStateSelected = newDayState == DayState.Selected;
             control.IsDayStateInvalid = newDayState == DayState.Invalid;
+
+            control.UpdateView();
         }
-        private static void StateAppearanceChanged(BindableObject bindable, object oldValue, object newValue)
+        private static void CurrentMonthStylePropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             DayView control = (DayView)bindable;
 
             control.UpdateView();
         }
-        private static object CoerceDayState (BindableObject bindable, object value)
+        private static void OtherMonthStylePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            DayView control = (DayView)bindable;
+
+            control.UpdateView();
+        }
+        private static void TodayStylePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            DayView control = (DayView)bindable;
+
+            control.UpdateView();
+        }
+        private static void SelectedStylePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            DayView control = (DayView)bindable;
+            Style newSelectedStyle = (Style)newValue;
+
+            if (control.DayState == DayState.Selected)
+            {
+                control.Style = newSelectedStyle;
+            }
+        }
+        private static void InvalidStylePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            DayView control = (DayView)bindable;
+
+            control.UpdateView();
+        }
+        private static object CoerceDayState(BindableObject bindable, object value)
         {
             DayView control = (DayView)bindable;
 

--- a/XCalendar.Maui/Styles/DefaultStyles.cs
+++ b/XCalendar.Maui/Styles/DefaultStyles.cs
@@ -1,0 +1,58 @@
+﻿using XCalendar.Maui.Views;
+
+namespace XCalendar.Maui.Styles
+{
+    public static class DefaultStyles
+    {
+        #region Properties
+        public static Style DefaultDayViewCurrentMonthStyle { get; } = CreateDefaultDayViewCurrentMonthStyle();
+        public static Style DefaultDayViewOtherMonthStyle { get; } = CreateDefaultDayViewOtherMonthStyle();
+        public static Style DefaultDayViewTodayStyle { get; } = CreateDefaultDayViewTodayStyle();
+        public static Style DefaultDayViewSelectedStyle { get; } = CreateDefaultDayViewSelectedStyle();
+        public static Style DefaultDayViewInvalidStyle { get; } = CreateDefaultDayViewInvalidStyle();
+        #endregion
+
+        #region Methods
+        public static Style CreateDefaultDayViewCurrentMonthStyle()
+        {
+            Style style = new Style(typeof(DayView)) { CanCascade = true };
+            style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Colors.Transparent });
+            style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Colors.Black });
+
+            return style;
+        }
+        public static Style CreateDefaultDayViewOtherMonthStyle()
+        {
+            Style style = new Style(typeof(DayView)) { CanCascade = true };
+            style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Colors.Transparent });
+            style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Color.FromArgb("#A0A0A0") });
+
+            return style;
+        }
+        public static Style CreateDefaultDayViewTodayStyle()
+        {
+            Style style = new Style(typeof(DayView)) { CanCascade = true };
+            style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Colors.Transparent });
+            style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Colors.Black });
+
+            return style;
+        }
+        public static Style CreateDefaultDayViewSelectedStyle()
+        {
+            Style style = new Style(typeof(DayView)) { CanCascade = true };
+            style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Color.FromArgb("#E00000") });
+            style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Colors.Black });
+
+            return style;
+        }
+        public static Style CreateDefaultDayViewInvalidStyle()
+        {
+            Style style = new Style(typeof(DayView)) { CanCascade = true };
+            style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Colors.Transparent });
+            style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Color.FromArgb("#FFA0A0") });
+
+            return style;
+        }
+        #endregion
+    }
+}

--- a/XCalendar.Maui/Views/DayView.xaml.cs
+++ b/XCalendar.Maui/Views/DayView.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows.Input;
 using XCalendar.Core.Enums;
+using XCalendar.Maui.Styles;
 
 namespace XCalendar.Maui.Views
 {
@@ -68,105 +69,30 @@ namespace XCalendar.Maui.Views
             get { return (bool)GetValue(IsDayStateInvalidProperty); }
             set { SetValue(IsDayStateInvalidProperty, value); }
         }
-        public Color CurrentMonthTextColor
+        public Style CurrentMonthStyle
         {
-            get { return (Color)GetValue(CurrentMonthTextColorProperty); }
-            set { SetValue(CurrentMonthTextColorProperty, value); }
+            get { return (Style)GetValue(CurrentMonthStyleProperty); }
+            set { SetValue(CurrentMonthStyleProperty, value); }
         }
-        public Color CurrentMonthBackgroundColor
+        public Style TodayStyle
         {
-            get { return (Color)GetValue(CurrentMonthBackgroundColorProperty); }
-            set { SetValue(CurrentMonthBackgroundColorProperty, value); }
+            get { return (Style)GetValue(TodayStyleProperty); }
+            set { SetValue(TodayStyleProperty, value); }
         }
-        public ICommand CurrentMonthCommand
+        public Style OtherMonthStyle
         {
-            get { return (ICommand)GetValue(CurrentMonthCommandProperty); }
-            set { SetValue(CurrentMonthCommandProperty, value); }
+            get { return (Style)GetValue(OtherMonthStyleProperty); }
+            set { SetValue(OtherMonthStyleProperty, value); }
         }
-        public object CurrentMonthCommandParameter
+        public Style InvalidStyle
         {
-            get { return (object)GetValue(CurrentMonthCommandParameterProperty); }
-            set { SetValue(CurrentMonthCommandParameterProperty, value); }
+            get { return (Style)GetValue(InvalidStyleProperty); }
+            set { SetValue(InvalidStyleProperty, value); }
         }
-        public Color TodayTextColor
+        public Style SelectedStyle
         {
-            get { return (Color)GetValue(TodayTextColorProperty); }
-            set { SetValue(TodayTextColorProperty, value); }
-        }
-        public Color TodayBackgroundColor
-        {
-            get { return (Color)GetValue(TodayBackgroundColorProperty); }
-            set { SetValue(TodayBackgroundColorProperty, value); }
-        }
-        public ICommand TodayCommand
-        {
-            get { return (ICommand)GetValue(TodayCommandProperty); }
-            set { SetValue(TodayCommandProperty, value); }
-        }
-        public object TodayCommandParameter
-        {
-            get { return (object)GetValue(TodayCommandParameterProperty); }
-            set { SetValue(TodayCommandParameterProperty, value); }
-        }
-        public Color OtherMonthTextColor
-        {
-            get { return (Color)GetValue(OtherMonthTextColorProperty); }
-            set { SetValue(OtherMonthTextColorProperty, value); }
-        }
-        public Color OtherMonthBackgroundColor
-        {
-            get { return (Color)GetValue(OtherMonthBackgroundColorProperty); }
-            set { SetValue(OtherMonthBackgroundColorProperty, value); }
-        }
-        public ICommand OtherMonthCommand
-        {
-            get { return (ICommand)GetValue(OtherMonthCommandProperty); }
-            set { SetValue(OtherMonthCommandProperty, value); }
-        }
-        public object OtherMonthCommandParameter
-        {
-            get { return (object)GetValue(OtherMonthCommandParameterProperty); }
-            set { SetValue(OtherMonthCommandParameterProperty, value); }
-        }
-        public Color InvalidTextColor
-        {
-            get { return (Color)GetValue(InvalidTextColorProperty); }
-            set { SetValue(InvalidTextColorProperty, value); }
-        }
-        public Color InvalidBackgroundColor
-        {
-            get { return (Color)GetValue(InvalidBackgroundColorProperty); }
-            set { SetValue(InvalidBackgroundColorProperty, value); }
-        }
-        public ICommand InvalidCommand
-        {
-            get { return (ICommand)GetValue(InvalidCommandProperty); }
-            set { SetValue(InvalidCommandProperty, value); }
-        }
-        public object InvalidCommandParameter
-        {
-            get { return (object)GetValue(InvalidCommandParameterProperty); }
-            set { SetValue(InvalidCommandParameterProperty, value); }
-        }
-        public Color SelectedTextColor
-        {
-            get { return (Color)GetValue(SelectedTextColorProperty); }
-            set { SetValue(SelectedTextColorProperty, value); }
-        }
-        public Color SelectedBackgroundColor
-        {
-            get { return (Color)GetValue(SelectedBackgroundColorProperty); }
-            set { SetValue(SelectedBackgroundColorProperty, value); }
-        }
-        public ICommand SelectedCommand
-        {
-            get { return (ICommand)GetValue(SelectedCommandProperty); }
-            set { SetValue(SelectedCommandProperty, value); }
-        }
-        public object SelectedCommandParameter
-        {
-            get { return (object)GetValue(SelectedCommandParameterProperty); }
-            set { SetValue(SelectedCommandParameterProperty, value); }
+            get { return (Style)GetValue(SelectedStyleProperty); }
+            set { SetValue(SelectedStyleProperty, value); }
         }
         public ICommand Command
         {
@@ -257,7 +183,7 @@ namespace XCalendar.Maui.Views
 
         #region Bindable Properties Initialisers
         public static readonly BindableProperty DateTimeProperty = BindableProperty.Create(nameof(DateTime), typeof(DateTime?), typeof(DayView), System.DateTime.Today, propertyChanged: DateTimePropertyChanged);
-        public static readonly BindableProperty DayStateProperty = BindableProperty.Create(nameof(DayState), typeof(DayState), typeof(DayView), propertyChanged: DayStatePropertyChanged, coerceValue: CoerceDayState);
+        public static readonly BindableProperty DayStateProperty = BindableProperty.Create(nameof(DayState), typeof(DayState), typeof(DayView), DayState.CurrentMonth, propertyChanged: DayStatePropertyChanged, coerceValue: CoerceDayState);
         public static readonly BindableProperty IsCurrentMonthProperty = BindableProperty.Create(nameof(IsCurrentMonth), typeof(bool), typeof(DayView), true, propertyChanged: IsCurrentMonthPropertyChanged);
         public static readonly BindableProperty IsOtherMonthProperty = BindableProperty.Create(nameof(IsOtherMonth), typeof(bool), typeof(DayView), propertyChanged: IsOtherMonthPropertyChanged);
         public static readonly BindableProperty IsTodayProperty = BindableProperty.Create(nameof(IsToday), typeof(bool), typeof(DayView), propertyChanged: IsTodayPropertyChanged);
@@ -268,26 +194,11 @@ namespace XCalendar.Maui.Views
         public static readonly BindableProperty IsDayStateTodayProperty = BindableProperty.Create(nameof(IsDayStateToday), typeof(bool), typeof(DayView));
         public static readonly BindableProperty IsDayStateSelectedProperty = BindableProperty.Create(nameof(IsDayStateSelected), typeof(bool), typeof(DayView));
         public static readonly BindableProperty IsDayStateInvalidProperty = BindableProperty.Create(nameof(IsDayStateInvalid), typeof(bool), typeof(DayView));
-        public static readonly BindableProperty CurrentMonthTextColorProperty = BindableProperty.Create(nameof(CurrentMonthTextColor), typeof(Color), typeof(DayView), Colors.Black, propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty CurrentMonthBackgroundColorProperty = BindableProperty.Create(nameof(CurrentMonthBackgroundColor), typeof(Color), typeof(DayView), Colors.Transparent, propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty CurrentMonthCommandProperty = BindableProperty.Create(nameof(CurrentMonthCommand), typeof(ICommand), typeof(DayView), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty CurrentMonthCommandParameterProperty = BindableProperty.Create(nameof(CurrentMonthCommandParameter), typeof(object), typeof(DayView), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty TodayTextColorProperty = BindableProperty.Create(nameof(TodayTextColor), typeof(Color), typeof(DayView), Colors.Black, propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty TodayBackgroundColorProperty = BindableProperty.Create(nameof(TodayBackgroundColor), typeof(Color), typeof(DayView), Colors.Transparent, propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty TodayCommandProperty = BindableProperty.Create(nameof(TodayCommand), typeof(ICommand), typeof(DayView), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty TodayCommandParameterProperty = BindableProperty.Create(nameof(TodayCommandParameter), typeof(object), typeof(DayView), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty OtherMonthTextColorProperty = BindableProperty.Create(nameof(OtherMonthTextColor), typeof(Color), typeof(DayView), Color.FromArgb("#FFA0A0A0"), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty OtherMonthBackgroundColorProperty = BindableProperty.Create(nameof(OtherMonthBackgroundColor), typeof(Color), typeof(DayView), Colors.Transparent, propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty OtherMonthCommandProperty = BindableProperty.Create(nameof(OtherMonthCommand), typeof(ICommand), typeof(DayView), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty OtherMonthCommandParameterProperty = BindableProperty.Create(nameof(OtherMonthCommandParameter), typeof(object), typeof(DayView), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty InvalidTextColorProperty = BindableProperty.Create(nameof(InvalidTextColor), typeof(Color), typeof(DayView), Color.FromArgb("#FFFFA0A0"), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty InvalidBackgroundColorProperty = BindableProperty.Create(nameof(InvalidBackgroundColor), typeof(Color), typeof(DayView), Colors.Transparent, propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty InvalidCommandProperty = BindableProperty.Create(nameof(InvalidCommand), typeof(ICommand), typeof(DayView), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty InvalidCommandParameterProperty = BindableProperty.Create(nameof(InvalidCommandParameter), typeof(object), typeof(DayView), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty SelectedTextColorProperty = BindableProperty.Create(nameof(SelectedTextColor), typeof(Color), typeof(DayView), Colors.White, propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty SelectedBackgroundColorProperty = BindableProperty.Create(nameof(SelectedBackgroundColor), typeof(Color), typeof(DayView), Color.FromArgb("#FFE00000"), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty SelectedCommandProperty = BindableProperty.Create(nameof(SelectedCommand), typeof(ICommand), typeof(DayView), propertyChanged: StateAppearanceChanged);
-        public static readonly BindableProperty SelectedCommandParameterProperty = BindableProperty.Create(nameof(SelectedCommandParameter), typeof(object), typeof(DayView), propertyChanged: StateAppearanceChanged);
+        public static readonly BindableProperty CurrentMonthStyleProperty = BindableProperty.Create(nameof(CurrentMonthStyle), typeof(Style), typeof(DayView), propertyChanged: CurrentMonthStylePropertyChanged, defaultValueCreator: CreateDefaultDayViewCurrentMonthStyle);
+        public static readonly BindableProperty OtherMonthStyleProperty = BindableProperty.Create(nameof(OtherMonthStyle), typeof(Style), typeof(DayView), propertyChanged: OtherMonthStylePropertyChanged, defaultValueCreator: CreateDefaultDayViewOtherMonthStyle);
+        public static readonly BindableProperty TodayStyleProperty = BindableProperty.Create(nameof(TodayStyle), typeof(Style), typeof(DayView), propertyChanged: TodayStylePropertyChanged, defaultValueCreator: CreateDefaultDayViewTodayStyle);
+        public static readonly BindableProperty SelectedStyleProperty = BindableProperty.Create(nameof(SelectedStyle), typeof(Style), typeof(DayView), propertyChanged: SelectedStylePropertyChanged, defaultValueCreator: CreateDefaultDayViewSelectedStyle);
+        public static readonly BindableProperty InvalidStyleProperty = BindableProperty.Create(nameof(InvalidStyle), typeof(Style), typeof(DayView), propertyChanged: InvalidStylePropertyChanged, defaultValueCreator: CreateDefaultDayViewInvalidStyle);
         public static readonly BindableProperty CommandProperty = BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(DayView));
         public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(DayView));
         public static readonly BindableProperty CharacterSpacingProperty = BindableProperty.Create(nameof(CharacterSpacing), typeof(double), typeof(DayView), Label.CharacterSpacingProperty.DefaultValue);
@@ -313,7 +224,6 @@ namespace XCalendar.Maui.Views
         public DayView()
         {
             SetBinding(TextProperty, new Binding(path: "DateTime.Day", source: this));
-            DayState = DayState.CurrentMonth;
 
             InitializeComponent();
         }
@@ -354,39 +264,23 @@ namespace XCalendar.Maui.Views
             switch (DayState)
             {
                 case DayState.CurrentMonth:
-                    BackgroundColor = CurrentMonthBackgroundColor;
-                    TextColor = CurrentMonthTextColor;
-                    Command = CurrentMonthCommand;
-                    CommandParameter = CurrentMonthCommandParameter;
+                    Style = CurrentMonthStyle;
                     break;
 
                 case DayState.OtherMonth:
-                    BackgroundColor = OtherMonthBackgroundColor;
-                    TextColor = OtherMonthTextColor;
-                    Command = OtherMonthCommand;
-                    CommandParameter = OtherMonthCommandParameter;
+                    Style = OtherMonthStyle;
                     break;
 
                 case DayState.Today:
-                    BackgroundColor = TodayBackgroundColor;
-                    TextColor = TodayTextColor;
-                    Command = TodayCommand;
-                    CommandParameter = TodayCommandParameter;
+                    Style = TodayStyle;
                     break;
 
                 case DayState.Selected:
-                    BackgroundColor = SelectedBackgroundColor;
-                    TextColor = SelectedTextColor;
-                    Command = SelectedCommand;
-                    CommandParameter = SelectedCommandParameter;
+                    Style = SelectedStyle;
                     break;
 
                 case DayState.Invalid:
-                    BackgroundColor = InvalidBackgroundColor;
-                    TextColor = InvalidTextColor;
-                    Command = InvalidCommand;
-                    CommandParameter = InvalidCommandParameter;
-
+                    Style = InvalidStyle;
                     break;
 
                 default:
@@ -395,47 +289,66 @@ namespace XCalendar.Maui.Views
         }
 
         #region Bindable Properties Methods
+        private static object CreateDefaultDayViewCurrentMonthStyle(BindableObject bindable)
+        {
+            //Default value doesn't work so a DefaultValueCreator is used instead.
+            return DefaultStyles.DefaultDayViewCurrentMonthStyle;
+        }
+        private static object CreateDefaultDayViewOtherMonthStyle(BindableObject bindable)
+        {
+            //Default value doesn't work so a DefaultValueCreator is used instead.
+            return DefaultStyles.DefaultDayViewOtherMonthStyle;
+        }
+        private static object CreateDefaultDayViewTodayStyle(BindableObject bindable)
+        {
+            //Default value doesn't work so a DefaultValueCreator is used instead.
+            return DefaultStyles.DefaultDayViewTodayStyle;
+        }
+        private static object CreateDefaultDayViewSelectedStyle(BindableObject bindable)
+        {
+            //Default value doesn't work so a DefaultValueCreator is used instead.
+            return DefaultStyles.DefaultDayViewSelectedStyle;
+        }
+        private static object CreateDefaultDayViewInvalidStyle(BindableObject bindable)
+        {
+            //Default value doesn't work so a DefaultValueCreator is used instead.
+            return DefaultStyles.DefaultDayViewInvalidStyle;
+        }
         private static void DateTimePropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             DayView control = (DayView)bindable;
 
             control.DayState = control.EvaluateDayState();
-            control.UpdateView();
         }
         private static void IsCurrentMonthPropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             DayView control = (DayView)bindable;
 
             control.DayState = control.EvaluateDayState();
-            control.UpdateView();
         }
         private static void IsOtherMonthPropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             DayView control = (DayView)bindable;
 
             control.DayState = control.EvaluateDayState();
-            control.UpdateView();
         }
         private static void IsTodayPropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             DayView control = (DayView)bindable;
 
             control.DayState = control.EvaluateDayState();
-            control.UpdateView();
         }
         private static void IsSelectedPropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             DayView control = (DayView)bindable;
 
             control.DayState = control.EvaluateDayState();
-            control.UpdateView();
         }
         private static void IsInvalidPropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             DayView control = (DayView)bindable;
 
             control.DayState = control.EvaluateDayState();
-            control.UpdateView();
         }
         private static void DayStatePropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
@@ -447,8 +360,38 @@ namespace XCalendar.Maui.Views
             control.IsDayStateToday = newDayState == DayState.Today;
             control.IsDayStateSelected = newDayState == DayState.Selected;
             control.IsDayStateInvalid = newDayState == DayState.Invalid;
+
+            control.UpdateView();
         }
-        private static void StateAppearanceChanged(BindableObject bindable, object oldValue, object newValue)
+        private static void CurrentMonthStylePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            DayView control = (DayView)bindable;
+
+            control.UpdateView();
+        }
+        private static void OtherMonthStylePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            DayView control = (DayView)bindable;
+
+            control.UpdateView();
+        }
+        private static void TodayStylePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            DayView control = (DayView)bindable;
+
+            control.UpdateView();
+        }
+        private static void SelectedStylePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            DayView control = (DayView)bindable;
+            Style newSelectedStyle = (Style)newValue;
+
+            if (control.DayState == DayState.Selected)
+            {
+                control.Style = newSelectedStyle;
+            }
+        }
+        private static void InvalidStylePropertyChanged(BindableObject bindable, object oldValue, object newValue)
         {
             DayView control = (DayView)bindable;
 

--- a/XCalendarFormsSample/XCalendarFormsSample.Android/Resources/Resource.designer.cs
+++ b/XCalendarFormsSample/XCalendarFormsSample.Android/Resources/Resource.designer.cs
@@ -14,7 +14,7 @@ namespace XCalendarSample.Droid
 {
 	
 	
-	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "13.2.0.93")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "13.2.0.99")]
 	public partial class Resource
 	{
 		

--- a/XCalendarFormsSample/XCalendarFormsSample/App.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/App.xaml
@@ -3,6 +3,7 @@
     x:Class="XCalendarFormsSample.App"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:Styles="clr-namespace:XCalendar.Forms.Styles;assembly=XCalendar.Forms"
     xmlns:xc="clr-namespace:XCalendar.Forms.Views;assembly=XCalendar.Forms"
     xmlns:xct="http://xamarin.com/schemas/2020/toolkit">
 
@@ -50,12 +51,36 @@
             <Setter Property="HeightRequest" Value="50"/>
         </Style>
 
-        <Style x:Key="DefaultDayViewStyle" TargetType="{x:Type xc:DayView}">
-            <Setter Property="CurrentMonthTextColor" Value="{StaticResource CalendarBackgroundTextColor}"/>
-            <Setter Property="TodayTextColor" Value="{StaticResource CalendarPrimaryColor}"/>
-            <Setter Property="InvalidTextColor" Value="{StaticResource CalendarTertiaryColor}"/>
-            <Setter Property="SelectedBackgroundColor" Value="{StaticResource CalendarPrimaryColor}"/>
-            <Setter Property="SelectedTextColor" Value="{StaticResource CalendarPrimaryTextColor}"/>
+        <Style
+            x:Key="DefaultDayViewCurrentMonthStyle"
+            BasedOn="{x:Static Styles:DefaultStyles.DefaultDayViewCurrentMonthStyle}"
+            TargetType="{x:Type xc:DayView}"/>
+
+        <Style
+            x:Key="DefaultDayViewOtherMonthStyle"
+            BasedOn="{x:Static Styles:DefaultStyles.DefaultDayViewOtherMonthStyle}"
+            TargetType="{x:Type xc:DayView}"/>
+
+        <Style
+            x:Key="DefaultDayViewTodayStyle"
+            BasedOn="{x:Static Styles:DefaultStyles.DefaultDayViewTodayStyle}"
+            TargetType="{x:Type xc:DayView}">
+            <Setter Property="TextColor" Value="{StaticResource CalendarPrimaryColor}"/>
+        </Style>
+
+        <Style
+            x:Key="DefaultDayViewSelectedStyle"
+            BasedOn="{x:Static Styles:DefaultStyles.DefaultDayViewSelectedStyle}"
+            TargetType="{x:Type xc:DayView}">
+            <Setter Property="BackgroundColor" Value="{StaticResource CalendarPrimaryColor}"/>
+            <Setter Property="TextColor" Value="{StaticResource CalendarPrimaryTextColor}"/>
+        </Style>
+
+        <Style
+            x:Key="DefaultDayViewInvalidStyle"
+            BasedOn="{x:Static Styles:DefaultStyles.DefaultDayViewInvalidStyle}"
+            TargetType="{x:Type xc:DayView}">
+            <Setter Property="TextColor" Value="{StaticResource CalendarTertiaryColor}"/>
         </Style>
 
         <Style x:Key="DefaultPageStyle" TargetType="{x:Type ContentPage}">

--- a/XCalendarFormsSample/XCalendarFormsSample/Popups/DatePickerDialogPopup.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Popups/DatePickerDialogPopup.xaml
@@ -98,26 +98,53 @@
                         CornerRadius="100"
                         HeightRequest="39">
                         <xc:DayView
-                            CurrentMonthBackgroundColor="Transparent"
-                            CurrentMonthCommand="{Binding ChangeDateSelectionCommand, Source={x:Reference This}}"
-                            CurrentMonthCommandParameter="{Binding DateTime}"
-                            CurrentMonthTextColor="Black"
                             DateTime="{Binding DateTime}"
                             FontSize="12"
-                            InvalidBackgroundColor="Transparent"
                             IsCurrentMonth="{Binding IsCurrentMonth}"
                             IsInvalid="{Binding IsInvalid}"
                             IsSelected="{Binding IsSelected}"
-                            IsToday="{Binding IsToday}"
-                            OtherMonthTextColor="Transparent"
-                            SelectedBackgroundColor="{StaticResource PrimaryColor}"
-                            SelectedCommand="{Binding ChangeDateSelectionCommand, Source={x:Reference This}}"
-                            SelectedCommandParameter="{Binding DateTime}"
-                            SelectedTextColor="White"
-                            TodayBackgroundColor="Transparent"
-                            TodayCommand="{Binding ChangeDateSelectionCommand, Source={x:Reference This}}"
-                            TodayCommandParameter="{Binding DateTime}"
-                            TodayTextColor="{StaticResource PrimaryColor}"/>
+                            IsToday="{Binding IsToday}">
+
+                            <xc:DayView.CurrentMonthStyle>
+                                <Style TargetType="{x:Type xc:DayView}">
+                                    <Setter Property="BackgroundColor" Value="Transparent"/>
+                                    <Setter Property="TextColor" Value="Black"/>
+                                    <Setter Property="Command" Value="{Binding ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                    <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                </Style>
+                            </xc:DayView.CurrentMonthStyle>
+
+                            <xc:DayView.OtherMonthStyle>
+                                <Style TargetType="{x:Type xc:DayView}">
+                                    <Setter Property="TextColor" Value="Transparent"/>
+                                </Style>
+                            </xc:DayView.OtherMonthStyle>
+
+                            <xc:DayView.TodayStyle>
+                                <Style TargetType="{x:Type xc:DayView}">
+                                    <Setter Property="BackgroundColor" Value="Transparent"/>
+                                    <Setter Property="TextColor" Value="{StaticResource PrimaryColor}"/>
+                                    <Setter Property="Command" Value="{Binding ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                    <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                </Style>
+                            </xc:DayView.TodayStyle>
+
+                            <xc:DayView.SelectedStyle>
+                                <Style TargetType="{x:Type xc:DayView}">
+                                    <Setter Property="BackgroundColor" Value="{StaticResource PrimaryColor}"/>
+                                    <Setter Property="TextColor" Value="White"/>
+                                    <Setter Property="Command" Value="{Binding ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                    <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                </Style>
+                            </xc:DayView.SelectedStyle>
+
+                            <xc:DayView.InvalidStyle>
+                                <Style TargetType="{x:Type xc:DayView}">
+                                    <Setter Property="BackgroundColor" Value="Transparent"/>
+                                </Style>
+                            </xc:DayView.InvalidStyle>
+
+                        </xc:DayView>
                     </Frame>
                 </DataTemplate>
             </xc:CalendarView.DayTemplate>

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/ConnectingSelectedDaysExamplePage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/ConnectingSelectedDaysExamplePage.xaml
@@ -59,18 +59,34 @@
                     <DataTemplate x:DataType="{x:Type Models:ConnectableDay}">
                         <ContentView>
                             <xc:DayView
-                                CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                CurrentMonthCommandParameter="{Binding DateTime}"
                                 DateTime="{Binding DateTime}"
+                                InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                                 IsCurrentMonth="{Binding IsCurrentMonth}"
                                 IsInvalid="{Binding IsInvalid}"
                                 IsSelected="{Binding IsSelected}"
                                 IsToday="{Binding IsToday}"
-                                SelectedCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                SelectedCommandParameter="{Binding DateTime}"
-                                Style="{StaticResource DefaultDayViewStyle}"
-                                TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                TodayCommandParameter="{Binding DateTime}">
+                                OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}">
+
+                                <xc:DayView.CurrentMonthStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.CurrentMonthStyle>
+
+                                <xc:DayView.TodayStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewTodayStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.TodayStyle>
+
+                                <xc:DayView.SelectedStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewSelectedStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.SelectedStyle>
 
                                 <!--
                                     The ControlTemplate should completely override the look of the control but this did not happen and the selected background color was still shown.

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/CustomisingADayExamplePage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/CustomisingADayExamplePage.xaml
@@ -51,20 +51,38 @@
                             CornerRadius="100"
                             HasShadow="False">
                             <xc:DayView
-                                CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                CurrentMonthCommandParameter="{Binding DateTime}"
                                 DateTime="{Binding DateTime}"
                                 FontAttributes="Bold"
                                 FontSize="18"
+                                InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                                 IsCurrentMonth="{Binding IsCurrentMonth}"
                                 IsInvalid="{Binding IsInvalid}"
                                 IsSelected="{Binding IsSelected}"
                                 IsToday="{Binding IsToday}"
-                                SelectedCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                SelectedCommandParameter="{Binding DateTime}"
-                                Style="{StaticResource DefaultDayViewStyle}"
-                                TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                TodayCommandParameter="{Binding DateTime}"/>
+                                OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}">
+                                
+                                <xc:DayView.CurrentMonthStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.CurrentMonthStyle>
+
+                                <xc:DayView.TodayStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewTodayStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.TodayStyle>
+
+                                <xc:DayView.SelectedStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewSelectedStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.SelectedStyle>
+
+                            </xc:DayView>
                         </Frame>
                     </ContentView>
                 </DataTemplate>

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/EventCalendarExamplePage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/EventCalendarExamplePage.xaml
@@ -83,19 +83,35 @@
                                 CornerRadius="100"
                                 HasShadow="False">
                                 <xc:DayView
-                                    CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                    CurrentMonthCommandParameter="{Binding DateTime}"
                                     DateTime="{Binding DateTime}"
                                     HeightRequest="41"
+                                    InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                                     IsCurrentMonth="{Binding IsCurrentMonth}"
                                     IsInvalid="{Binding IsInvalid}"
                                     IsSelected="{Binding IsSelected}"
                                     IsToday="{Binding IsToday}"
-                                    SelectedCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                    SelectedCommandParameter="{Binding DateTime}"
-                                    Style="{StaticResource DefaultDayViewStyle}"
-                                    TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                    TodayCommandParameter="{Binding DateTime}">
+                                    OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}">
+
+                                    <xc:DayView.CurrentMonthStyle>
+                                        <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">
+                                            <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                            <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                        </Style>
+                                    </xc:DayView.CurrentMonthStyle>
+
+                                    <xc:DayView.TodayStyle>
+                                        <Style BasedOn="{StaticResource DefaultDayViewTodayStyle}" TargetType="{x:Type xc:DayView}">
+                                            <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                            <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                        </Style>
+                                    </xc:DayView.TodayStyle>
+
+                                    <xc:DayView.SelectedStyle>
+                                        <Style BasedOn="{StaticResource DefaultDayViewSelectedStyle}" TargetType="{x:Type xc:DayView}">
+                                            <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                            <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                        </Style>
+                                    </xc:DayView.SelectedStyle>
 
                                     <xc:DayView.ControlTemplate>
                                         <ControlTemplate>

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/PlaygroundPage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/PlaygroundPage.xaml
@@ -954,30 +954,60 @@
                                     HorizontalOptions="Center"
                                     VerticalOptions="Center">
                                     <xc:DayView
-                                        CurrentMonthBackgroundColor="{Binding BindingContext.DayCurrentMonthBackgroundColor, Source={x:Reference This}}"
-                                        CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                        CurrentMonthCommandParameter="{Binding DateTime}"
-                                        CurrentMonthTextColor="{Binding BindingContext.DayCurrentMonthTextColor, Source={x:Reference This}}"
                                         DateTime="{Binding DateTime}"
                                         HeightRequest="{Binding BindingContext.DayHeightRequest, Source={x:Reference This}}"
-                                        InvalidBackgroundColor="{Binding BindingContext.DayInvalidBackgroundColor, Source={x:Reference This}}"
-                                        InvalidTextColor="{Binding BindingContext.DayInvalidTextColor, Source={x:Reference This}}"
                                         IsCurrentMonth="{Binding IsCurrentMonth}"
                                         IsInvalid="{Binding IsInvalid}"
                                         IsSelected="{Binding IsSelected}"
                                         IsToday="{Binding IsToday}"
-                                        OtherMonthBackgroundColor="{Binding BindingContext.DayOtherMonthBackgroundColor, Source={x:Reference This}}"
-                                        OtherMonthTextColor="{Binding BindingContext.DayOtherMonthTextColor, Source={x:Reference This}}"
-                                        SelectedBackgroundColor="{Binding BindingContext.DaySelectedBackgroundColor, Source={x:Reference This}}"
-                                        SelectedCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                        SelectedCommandParameter="{Binding DateTime}"
-                                        SelectedTextColor="{Binding BindingContext.DaySelectedTextColor, Source={x:Reference This}}"
-                                        Style="{StaticResource DefaultDayViewStyle}"
-                                        TodayBackgroundColor="{Binding BindingContext.DayTodayBackgroundColor, Source={x:Reference This}}"
-                                        TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                        TodayCommandParameter="{Binding DateTime}"
-                                        TodayTextColor="{Binding BindingContext.DayTodayTextColor, Source={x:Reference This}}"
-                                        WidthRequest="{Binding BindingContext.DayWidthRequest, Source={x:Reference This}}"/>
+                                        WidthRequest="{Binding BindingContext.DayWidthRequest, Source={x:Reference This}}">
+
+                                        <xc:DayView.CurrentMonthStyle>
+                                            <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">
+                                                <Setter Property="BackgroundColor" Value="{Binding BindingContext.DayCurrentMonthBackgroundColor, Source={x:Reference This}}"/>
+                                                <Setter Property="TextColor" Value="{Binding BindingContext.DayCurrentMonthTextColor, Source={x:Reference This}}"/>
+                                                <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                                <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                            </Style>
+                                        </xc:DayView.CurrentMonthStyle>
+
+                                        <xc:DayView.OtherMonthStyle>
+                                            <Style BasedOn="{StaticResource DefaultDayViewOtherMonthStyle}" TargetType="{x:Type xc:DayView}">
+                                                <Setter Property="BackgroundColor" Value="{Binding BindingContext.DayOtherMonthBackgroundColor, Source={x:Reference This}}"/>
+                                                <Setter Property="TextColor" Value="{Binding BindingContext.DayOtherMonthTextColor, Source={x:Reference This}}"/>
+                                                <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                                <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                            </Style>
+                                        </xc:DayView.OtherMonthStyle>
+
+                                        <xc:DayView.TodayStyle>
+                                            <Style BasedOn="{StaticResource DefaultDayViewTodayStyle}" TargetType="{x:Type xc:DayView}">
+                                                <Setter Property="BackgroundColor" Value="{Binding BindingContext.DayTodayBackgroundColor, Source={x:Reference This}}"/>
+                                                <Setter Property="TextColor" Value="{Binding BindingContext.DayTodayTextColor, Source={x:Reference This}}"/>
+                                                <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                                <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                            </Style>
+                                        </xc:DayView.TodayStyle>
+
+                                        <xc:DayView.SelectedStyle>
+                                            <Style BasedOn="{StaticResource DefaultDayViewSelectedStyle}" TargetType="{x:Type xc:DayView}">
+                                                <Setter Property="BackgroundColor" Value="{Binding BindingContext.DaySelectedBackgroundColor, Source={x:Reference This}}"/>
+                                                <Setter Property="TextColor" Value="{Binding BindingContext.DaySelectedTextColor, Source={x:Reference This}}"/>
+                                                <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                                <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                            </Style>
+                                        </xc:DayView.SelectedStyle>
+
+                                        <xc:DayView.InvalidStyle>
+                                            <Style BasedOn="{StaticResource DefaultDayViewInvalidStyle}" TargetType="{x:Type xc:DayView}">
+                                                <Setter Property="BackgroundColor" Value="{Binding BindingContext.DayInvalidBackgroundColor, Source={x:Reference This}}"/>
+                                                <Setter Property="TextColor" Value="{Binding BindingContext.DayInvalidTextColor, Source={x:Reference This}}"/>
+                                                <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                                <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                            </Style>
+                                        </xc:DayView.InvalidStyle>
+
+                                    </xc:DayView>
                                 </Frame>
                             </ContentView>
                         </DataTemplate>

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/SelectionExamplePage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/SelectionExamplePage.xaml
@@ -64,18 +64,36 @@
                                 CornerRadius="100"
                                 HasShadow="False">
                                 <xc:DayView
-                                    CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                    CurrentMonthCommandParameter="{Binding DateTime}"
                                     DateTime="{Binding DateTime}"
+                                    InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                                     IsCurrentMonth="{Binding IsCurrentMonth}"
                                     IsInvalid="{Binding IsInvalid}"
                                     IsSelected="{Binding IsSelected}"
                                     IsToday="{Binding IsToday}"
-                                    SelectedCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                    SelectedCommandParameter="{Binding DateTime}"
-                                    Style="{StaticResource DefaultDayViewStyle}"
-                                    TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                    TodayCommandParameter="{Binding DateTime}"/>
+                                    OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}">
+
+                                    <xc:DayView.CurrentMonthStyle>
+                                        <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">
+                                            <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                            <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                        </Style>
+                                    </xc:DayView.CurrentMonthStyle>
+
+                                    <xc:DayView.TodayStyle>
+                                        <Style BasedOn="{StaticResource DefaultDayViewTodayStyle}" TargetType="{x:Type xc:DayView}">
+                                            <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                            <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                        </Style>
+                                    </xc:DayView.TodayStyle>
+
+                                    <xc:DayView.SelectedStyle>
+                                        <Style BasedOn="{StaticResource DefaultDayViewSelectedStyle}" TargetType="{x:Type xc:DayView}">
+                                            <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                            <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                        </Style>
+                                    </xc:DayView.SelectedStyle>
+
+                                </xc:DayView>
                             </Frame>
                         </ContentView>
                     </DataTemplate>

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/SwipableCalendarExamplePage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/SwipableCalendarExamplePage.xaml
@@ -66,18 +66,36 @@
                                             CornerRadius="100"
                                             HasShadow="False">
                                             <xc:DayView
-                                                CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                                CurrentMonthCommandParameter="{Binding DateTime}"
                                                 DateTime="{Binding DateTime}"
+                                                InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                                                 IsCurrentMonth="{Binding IsCurrentMonth}"
                                                 IsInvalid="{Binding IsInvalid}"
                                                 IsSelected="{Binding IsSelected}"
                                                 IsToday="{Binding IsToday}"
-                                                SelectedCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                                SelectedCommandParameter="{Binding DateTime}"
-                                                Style="{StaticResource DefaultDayViewStyle}"
-                                                TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                                TodayCommandParameter="{Binding DateTime}"/>
+                                                OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}">
+
+                                                <xc:DayView.CurrentMonthStyle>
+                                                    <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">
+                                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                                    </Style>
+                                                </xc:DayView.CurrentMonthStyle>
+
+                                                <xc:DayView.TodayStyle>
+                                                    <Style BasedOn="{StaticResource DefaultDayViewTodayStyle}" TargetType="{x:Type xc:DayView}">
+                                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                                    </Style>
+                                                </xc:DayView.TodayStyle>
+
+                                                <xc:DayView.SelectedStyle>
+                                                    <Style BasedOn="{StaticResource DefaultDayViewSelectedStyle}" TargetType="{x:Type xc:DayView}">
+                                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                                    </Style>
+                                                </xc:DayView.SelectedStyle>
+
+                                            </xc:DayView>
                                         </Frame>
                                     </ContentView>
                                 </DataTemplate>

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/UsingDayViewExamplePage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/UsingDayViewExamplePage.xaml
@@ -53,19 +53,37 @@
                                 CornerRadius="100"
                                 HasShadow="False">
                                 <xc:DayView
-                                    CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                    CurrentMonthCommandParameter="{Binding DateTime}"
                                     DateTime="{Binding DateTime}"
                                     HeightRequest="47"
+                                    InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                                     IsCurrentMonth="{Binding IsCurrentMonth}"
                                     IsInvalid="{Binding IsInvalid}"
                                     IsSelected="{Binding IsSelected}"
                                     IsToday="{Binding IsToday}"
-                                    SelectedCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                    SelectedCommandParameter="{Binding DateTime}"
-                                    Style="{StaticResource DefaultDayViewStyle}"
-                                    TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                    TodayCommandParameter="{Binding DateTime}"/>
+                                    OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}">
+
+                                    <xc:DayView.CurrentMonthStyle>
+                                        <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">
+                                            <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                            <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                        </Style>
+                                    </xc:DayView.CurrentMonthStyle>
+
+                                    <xc:DayView.TodayStyle>
+                                        <Style BasedOn="{StaticResource DefaultDayViewTodayStyle}" TargetType="{x:Type xc:DayView}">
+                                            <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                            <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                        </Style>
+                                    </xc:DayView.TodayStyle>
+
+                                    <xc:DayView.SelectedStyle>
+                                        <Style BasedOn="{StaticResource DefaultDayViewSelectedStyle}" TargetType="{x:Type xc:DayView}">
+                                            <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                            <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                        </Style>
+                                    </xc:DayView.SelectedStyle>
+
+                                </xc:DayView>
                             </Frame>
                         </ContentView>
                     </DataTemplate>
@@ -92,18 +110,36 @@
                 HorizontalOptions="Center"
                 WidthRequest="47">
                 <xc:DayView
-                    CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                    CurrentMonthCommandParameter="{Binding OutsideCalendarDay.DateTime}"
                     DateTime="{Binding OutsideCalendarDay.DateTime}"
+                    InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                     IsCurrentMonth="{Binding OutsideCalendarDay.IsCurrentMonth}"
                     IsInvalid="{Binding OutsideCalendarDay.IsInvalid}"
                     IsSelected="{Binding OutsideCalendarDay.IsSelected}"
                     IsToday="{Binding OutsideCalendarDay.IsToday}"
-                    SelectedCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                    SelectedCommandParameter="{Binding OutsideCalendarDay.DateTime}"
-                    Style="{StaticResource DefaultDayViewStyle}"
-                    TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                    TodayCommandParameter="{Binding OutsideCalendarDay.DateTime}"/>
+                    OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}">
+
+                    <xc:DayView.CurrentMonthStyle>
+                        <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">
+                            <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                            <Setter Property="CommandParameter" Value="{Binding OutsideCalendarDay.DateTime}"/>
+                        </Style>
+                    </xc:DayView.CurrentMonthStyle>
+
+                    <xc:DayView.TodayStyle>
+                        <Style BasedOn="{StaticResource DefaultDayViewTodayStyle}" TargetType="{x:Type xc:DayView}">
+                            <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                            <Setter Property="CommandParameter" Value="{Binding OutsideCalendarDay.DateTime}"/>
+                        </Style>
+                    </xc:DayView.TodayStyle>
+
+                    <xc:DayView.SelectedStyle>
+                        <Style BasedOn="{StaticResource DefaultDayViewSelectedStyle}" TargetType="{x:Type xc:DayView}">
+                            <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                            <Setter Property="CommandParameter" Value="{Binding OutsideCalendarDay.DateTime}"/>
+                        </Style>
+                    </xc:DayView.SelectedStyle>
+
+                </xc:DayView>
             </Frame>
 
         </StackLayout>

--- a/XCalendarMauiSample/App.xaml
+++ b/XCalendarMauiSample/App.xaml
@@ -3,6 +3,7 @@
     x:Class="XCalendarMauiSample.App"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:Styles="clr-namespace:XCalendar.Maui.Styles;assembly=XCalendar.Maui"
     xmlns:xc="clr-namespace:XCalendar.Maui.Views;assembly=XCalendar.Maui">
 
     <Application.Resources>
@@ -51,12 +52,36 @@
             <Setter Property="HeightRequest" Value="50"/>
         </Style>
 
-        <Style x:Key="DefaultDayViewStyle" TargetType="{x:Type xc:DayView}">
-            <Setter Property="CurrentMonthTextColor" Value="{StaticResource CalendarBackgroundTextColor}"/>
-            <Setter Property="TodayTextColor" Value="{StaticResource CalendarPrimaryColor}"/>
-            <Setter Property="InvalidTextColor" Value="{StaticResource CalendarTertiaryColor}"/>
-            <Setter Property="SelectedBackgroundColor" Value="{StaticResource CalendarPrimaryColor}"/>
-            <Setter Property="SelectedTextColor" Value="{StaticResource CalendarPrimaryTextColor}"/>
+        <Style
+            x:Key="DefaultDayViewCurrentMonthStyle"
+            BasedOn="{x:Static Styles:DefaultStyles.DefaultDayViewCurrentMonthStyle}"
+            TargetType="{x:Type xc:DayView}"/>
+
+        <Style
+            x:Key="DefaultDayViewOtherMonthStyle"
+            BasedOn="{x:Static Styles:DefaultStyles.DefaultDayViewOtherMonthStyle}"
+            TargetType="{x:Type xc:DayView}"/>
+
+        <Style
+            x:Key="DefaultDayViewTodayStyle"
+            BasedOn="{x:Static Styles:DefaultStyles.DefaultDayViewTodayStyle}"
+            TargetType="{x:Type xc:DayView}">
+            <Setter Property="TextColor" Value="{StaticResource CalendarPrimaryColor}"/>
+        </Style>
+
+        <Style
+            x:Key="DefaultDayViewSelectedStyle"
+            BasedOn="{x:Static Styles:DefaultStyles.DefaultDayViewSelectedStyle}"
+            TargetType="{x:Type xc:DayView}">
+            <Setter Property="BackgroundColor" Value="{StaticResource CalendarPrimaryColor}"/>
+            <Setter Property="TextColor" Value="{StaticResource CalendarPrimaryTextColor}"/>
+        </Style>
+
+        <Style
+            x:Key="DefaultDayViewInvalidStyle"
+            BasedOn="{x:Static Styles:DefaultStyles.DefaultDayViewInvalidStyle}"
+            TargetType="{x:Type xc:DayView}">
+            <Setter Property="TextColor" Value="{StaticResource CalendarTertiaryColor}"/>
         </Style>
 
         <Style x:Key="DefaultPageStyle" TargetType="{x:Type ContentPage}">

--- a/XCalendarMauiSample/Popups/DatePickerDialogPopup.xaml
+++ b/XCalendarMauiSample/Popups/DatePickerDialogPopup.xaml
@@ -100,27 +100,54 @@
                             <Ellipse/>
                         </Border.StrokeShape>
 
-                        <xc:DayView
-                            CurrentMonthBackgroundColor="Transparent"
-                            CurrentMonthCommand="{Binding ChangeDateSelectionCommand, Source={x:Reference This}}"
-                            CurrentMonthCommandParameter="{Binding DateTime}"
-                            CurrentMonthTextColor="Black"
-                            DateTime="{Binding DateTime}"
-                            FontSize="12"
-                            InvalidBackgroundColor="Transparent"
-                            IsCurrentMonth="{Binding IsCurrentMonth}"
-                            IsInvalid="{Binding IsInvalid}"
-                            IsSelected="{Binding IsSelected}"
-                            IsToday="{Binding IsToday}"
-                            OtherMonthTextColor="Transparent"
-                            SelectedBackgroundColor="{StaticResource PrimaryColor}"
-                            SelectedCommand="{Binding ChangeDateSelectionCommand, Source={x:Reference This}}"
-                            SelectedCommandParameter="{Binding DateTime}"
-                            SelectedTextColor="White"
-                            TodayBackgroundColor="Transparent"
-                            TodayCommand="{Binding ChangeDateSelectionCommand, Source={x:Reference This}}"
-                            TodayCommandParameter="{Binding DateTime}"
-                            TodayTextColor="{StaticResource PrimaryColor}"/>
+						<xc:DayView
+							DateTime="{Binding DateTime}"
+							FontSize="12"
+							IsCurrentMonth="{Binding IsCurrentMonth}"
+							IsInvalid="{Binding IsInvalid}"
+							IsSelected="{Binding IsSelected}"
+							IsToday="{Binding IsToday}">
+
+							<xc:DayView.CurrentMonthStyle>
+								<Style TargetType="{x:Type xc:DayView}">
+									<Setter Property="BackgroundColor" Value="Transparent"/>
+									<Setter Property="TextColor" Value="Black"/>
+									<Setter Property="Command" Value="{Binding ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+									<Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+								</Style>
+							</xc:DayView.CurrentMonthStyle>
+
+							<xc:DayView.OtherMonthStyle>
+								<Style TargetType="{x:Type xc:DayView}">
+									<Setter Property="TextColor" Value="Transparent"/>
+								</Style>
+							</xc:DayView.OtherMonthStyle>
+
+							<xc:DayView.TodayStyle>
+								<Style TargetType="{x:Type xc:DayView}">
+									<Setter Property="BackgroundColor" Value="Transparent"/>
+									<Setter Property="TextColor" Value="{StaticResource PrimaryColor}"/>
+									<Setter Property="Command" Value="{Binding ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+									<Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+								</Style>
+							</xc:DayView.TodayStyle>
+
+							<xc:DayView.SelectedStyle>
+								<Style TargetType="{x:Type xc:DayView}">
+									<Setter Property="BackgroundColor" Value="{StaticResource PrimaryColor}"/>
+									<Setter Property="TextColor" Value="White"/>
+									<Setter Property="Command" Value="{Binding ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+									<Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+								</Style>
+							</xc:DayView.SelectedStyle>
+
+							<xc:DayView.InvalidStyle>
+								<Style TargetType="{x:Type xc:DayView}">
+									<Setter Property="BackgroundColor" Value="Transparent"/>
+								</Style>
+							</xc:DayView.InvalidStyle>
+
+						</xc:DayView>
 
                     </Border>
                 </DataTemplate>

--- a/XCalendarMauiSample/Views/ConnectingSelectedDaysExamplePage.xaml
+++ b/XCalendarMauiSample/Views/ConnectingSelectedDaysExamplePage.xaml
@@ -60,21 +60,37 @@
                 <xc:CalendarView.DayTemplate>
                     <DataTemplate x:DataType="{x:Type Models:ConnectableDay}">
                         <xc:DayView
-                            CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                            CurrentMonthCommandParameter="{Binding DateTime}"
                             DateTime="{Binding DateTime}"
                             HorizontalOptions="FillAndExpand"
+                            InvalidStyle="{StaticResource DefaultDayViewOtherMonthStyle}"
                             IsCurrentMonth="{Binding IsCurrentMonth}"
                             IsInvalid="{Binding IsInvalid}"
                             IsSelected="{Binding IsSelected}"
                             IsToday="{Binding IsToday}"
-                            SelectedCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                            SelectedCommandParameter="{Binding DateTime}"
-                            Style="{StaticResource DefaultDayViewStyle}"
-                            TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                            TodayCommandParameter="{Binding DateTime}"
+                            OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}"
                             VerticalOptions="FillAndExpand"
                             WidthRequest="-1">
+
+                            <xc:DayView.CurrentMonthStyle>
+                                <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">
+                                    <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                    <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                </Style>
+                            </xc:DayView.CurrentMonthStyle>
+
+                            <xc:DayView.TodayStyle>
+                                <Style BasedOn="{StaticResource DefaultDayViewTodayStyle}" TargetType="{x:Type xc:DayView}">
+                                    <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                    <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                </Style>
+                            </xc:DayView.TodayStyle>
+
+                            <xc:DayView.SelectedStyle>
+                                <Style BasedOn="{StaticResource DefaultDayViewSelectedStyle}" TargetType="{x:Type xc:DayView}">
+                                    <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                    <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                </Style>
+                            </xc:DayView.SelectedStyle>
 
                             <!--
                                 The ControlTemplate should completely override the look of the control but this did not happen and the selected background color was still shown.

--- a/XCalendarMauiSample/Views/CustomDatePickerDialogExamplePage.xaml
+++ b/XCalendarMauiSample/Views/CustomDatePickerDialogExamplePage.xaml
@@ -9,32 +9,62 @@
     Style="{StaticResource DefaultPageStyle}">
 
     <ScrollView VerticalScrollBarVisibility="Never">
-        <VerticalStackLayout Spacing="0" BackgroundColor="{StaticResource ContentBackgroundColor}">
+        <VerticalStackLayout BackgroundColor="{StaticResource ContentBackgroundColor}" Spacing="0">
 
             <ContentView Padding="10" BackgroundColor="{DynamicResource SecondaryColor}">
-                <Label FontSize="19" HorizontalTextAlignment="Center" FontAttributes="Bold" Text="Tap on a date to open a DatePicker" TextColor="{DynamicResource ContentTextColor}"/>
+                <Label
+                    FontAttributes="Bold"
+                    FontSize="19"
+                    HorizontalTextAlignment="Center"
+                    Text="Tap on a date to open a DatePicker"
+                    TextColor="{DynamicResource ContentTextColor}"/>
             </ContentView>
 
-            <BoxView HeightRequest="1" BackgroundColor="{DynamicResource SeparatorColor}"/>
+            <BoxView BackgroundColor="{DynamicResource SeparatorColor}" HeightRequest="1"/>
 
-            <VerticalStackLayout Padding="10" BackgroundColor="{DynamicResource SecondaryColor}" Spacing="0">
-                <Label FontSize="19" FontAttributes="Bold" Text="Native Dialog" TextColor="{DynamicResource ContentTextColor}"/>
-                <DatePicker FontSize="16" Date="{Binding SelectedDate}" Format="{}dd MMMM yyyy" TextColor="{StaticResource ContentTextColor}" BackgroundColor="{StaticResource ContentBackgroundColor}"/>
+            <VerticalStackLayout
+                Padding="10"
+                BackgroundColor="{DynamicResource SecondaryColor}"
+                Spacing="0">
+                <Label
+                    FontAttributes="Bold"
+                    FontSize="19"
+                    Text="Native Dialog"
+                    TextColor="{DynamicResource ContentTextColor}"/>
+                <DatePicker
+                    BackgroundColor="{StaticResource ContentBackgroundColor}"
+                    Date="{Binding SelectedDate}"
+                    FontSize="16"
+                    Format="{}dd MMMM yyyy"
+                    TextColor="{StaticResource ContentTextColor}"/>
             </VerticalStackLayout>
 
-            <BoxView HeightRequest="1" BackgroundColor="{DynamicResource SeparatorColor}"/>
+            <BoxView BackgroundColor="{DynamicResource SeparatorColor}" HeightRequest="1"/>
 
-            <VerticalStackLayout Padding="10" BackgroundColor="{DynamicResource SecondaryColor}" Spacing="0">
-                <Label FontSize="19" FontAttributes="Bold" Text="Custom Dialog" TextColor="{DynamicResource ContentTextColor}"/>
-                <Label Margin="0,5,0,0" Padding="0,5,0,5" Text="{Binding SelectedDate, StringFormat='{0: dd MMMM yyyy}'}" FontSize="16" BackgroundColor="{StaticResource ContentBackgroundColor}" TextColor="{StaticResource ContentTextColor}">
+            <VerticalStackLayout
+                Padding="10"
+                BackgroundColor="{DynamicResource SecondaryColor}"
+                Spacing="0">
+                <Label
+                    FontAttributes="Bold"
+                    FontSize="19"
+                    Text="Custom Dialog"
+                    TextColor="{DynamicResource ContentTextColor}"/>
+                <Label
+                    Margin="0,5,0,0"
+                    Padding="0,5,0,5"
+                    BackgroundColor="{StaticResource ContentBackgroundColor}"
+                    FontSize="16"
+                    Text="{Binding SelectedDate, StringFormat='{0: dd MMMM yyyy}'}"
+                    TextColor="{StaticResource ContentTextColor}">
                     <Label.GestureRecognizers>
                         <TapGestureRecognizer Command="{Binding ShowDatePickerDialogCommand}" CommandParameter="{Binding SelectedDate}"/>
                     </Label.GestureRecognizers>
                 </Label>
-                <BoxView HeightRequest="1" BackgroundColor="Black"/>
+                <BoxView BackgroundColor="Black" HeightRequest="1"/>
             </VerticalStackLayout>
 
-            <BoxView HeightRequest="1" BackgroundColor="{DynamicResource SeparatorColor}"/>
+            <BoxView BackgroundColor="{DynamicResource SeparatorColor}" HeightRequest="1"/>
         </VerticalStackLayout>
     </ScrollView>
 

--- a/XCalendarMauiSample/Views/CustomisingADayExamplePage.xaml
+++ b/XCalendarMauiSample/Views/CustomisingADayExamplePage.xaml
@@ -55,20 +55,38 @@
                         </Border.StrokeShape>
 
                         <xc:DayView
-                            CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                            CurrentMonthCommandParameter="{Binding DateTime}"
                             DateTime="{Binding DateTime}"
                             FontAttributes="Bold"
                             FontSize="18"
+                            InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                             IsCurrentMonth="{Binding IsCurrentMonth}"
                             IsInvalid="{Binding IsInvalid}"
                             IsSelected="{Binding IsSelected}"
                             IsToday="{Binding IsToday}"
-                            SelectedCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                            SelectedCommandParameter="{Binding DateTime}"
-                            Style="{StaticResource DefaultDayViewStyle}"
-                            TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                            TodayCommandParameter="{Binding DateTime}"/>
+                            OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}">
+
+                            <xc:DayView.CurrentMonthStyle>
+                                <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">
+                                    <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                    <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                </Style>
+                            </xc:DayView.CurrentMonthStyle>
+
+                            <xc:DayView.TodayStyle>
+                                <Style BasedOn="{StaticResource DefaultDayViewTodayStyle}" TargetType="{x:Type xc:DayView}">
+                                    <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                    <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                </Style>
+                            </xc:DayView.TodayStyle>
+
+                            <xc:DayView.SelectedStyle>
+                                <Style BasedOn="{StaticResource DefaultDayViewSelectedStyle}" TargetType="{x:Type xc:DayView}">
+                                    <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                    <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                </Style>
+                            </xc:DayView.SelectedStyle>
+
+                        </xc:DayView>
                     </Border>
                 </DataTemplate>
             </xc:CalendarView.DayTemplate>

--- a/XCalendarMauiSample/Views/EventCalendarExamplePage.xaml
+++ b/XCalendarMauiSample/Views/EventCalendarExamplePage.xaml
@@ -87,18 +87,34 @@
                             </Border.StrokeShape>
 
                             <xc:DayView
-                                CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                CurrentMonthCommandParameter="{Binding DateTime}"
                                 DateTime="{Binding DateTime}"
+                                InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                                 IsCurrentMonth="{Binding IsCurrentMonth}"
                                 IsInvalid="{Binding IsInvalid}"
                                 IsSelected="{Binding IsSelected}"
                                 IsToday="{Binding IsToday}"
-                                SelectedCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                SelectedCommandParameter="{Binding DateTime}"
-                                Style="{StaticResource DefaultDayViewStyle}"
-                                TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                TodayCommandParameter="{Binding DateTime}">
+                                OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}">
+
+                                <xc:DayView.CurrentMonthStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.CurrentMonthStyle>
+
+                                <xc:DayView.TodayStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewTodayStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.TodayStyle>
+
+                                <xc:DayView.SelectedStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewSelectedStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.SelectedStyle>
 
                                 <xc:DayView.ControlTemplate>
                                     <ControlTemplate>

--- a/XCalendarMauiSample/Views/PlaygroundPage.xaml
+++ b/XCalendarMauiSample/Views/PlaygroundPage.xaml
@@ -998,28 +998,58 @@
                             </Border.StrokeShape>
 
                             <xc:DayView
-                                CurrentMonthBackgroundColor="{Binding BindingContext.DayCurrentMonthBackgroundColor, Source={x:Reference This}}"
-                                CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                CurrentMonthCommandParameter="{Binding DateTime}"
-                                CurrentMonthTextColor="{Binding BindingContext.DayCurrentMonthTextColor, Source={x:Reference This}}"
                                 DateTime="{Binding DateTime}"
-                                InvalidBackgroundColor="{Binding BindingContext.DayInvalidBackgroundColor, Source={x:Reference This}}"
-                                InvalidTextColor="{Binding BindingContext.DayInvalidTextColor, Source={x:Reference This}}"
                                 IsCurrentMonth="{Binding IsCurrentMonth}"
                                 IsInvalid="{Binding IsInvalid}"
                                 IsSelected="{Binding IsSelected}"
-                                IsToday="{Binding IsToday}"
-                                OtherMonthBackgroundColor="{Binding BindingContext.DayOtherMonthBackgroundColor, Source={x:Reference This}}"
-                                OtherMonthTextColor="{Binding BindingContext.DayOtherMonthTextColor, Source={x:Reference This}}"
-                                SelectedBackgroundColor="{Binding BindingContext.DaySelectedBackgroundColor, Source={x:Reference This}}"
-                                SelectedCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                SelectedCommandParameter="{Binding DateTime}"
-                                SelectedTextColor="{Binding BindingContext.DaySelectedTextColor, Source={x:Reference This}}"
-                                Style="{StaticResource DefaultDayViewStyle}"
-                                TodayBackgroundColor="{Binding BindingContext.DayTodayBackgroundColor, Source={x:Reference This}}"
-                                TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                TodayCommandParameter="{Binding DateTime}"
-                                TodayTextColor="{Binding BindingContext.DayTodayTextColor, Source={x:Reference This}}"/>
+                                IsToday="{Binding IsToday}">
+
+                                <xc:DayView.CurrentMonthStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="BackgroundColor" Value="{Binding BindingContext.DayCurrentMonthBackgroundColor, Source={x:Reference This}}"/>
+                                        <Setter Property="TextColor" Value="{Binding BindingContext.DayCurrentMonthTextColor, Source={x:Reference This}}"/>
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.CurrentMonthStyle>
+
+                                <xc:DayView.OtherMonthStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewOtherMonthStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="BackgroundColor" Value="{Binding BindingContext.DayOtherMonthBackgroundColor, Source={x:Reference This}}"/>
+                                        <Setter Property="TextColor" Value="{Binding BindingContext.DayOtherMonthTextColor, Source={x:Reference This}}"/>
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.OtherMonthStyle>
+
+                                <xc:DayView.TodayStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewTodayStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="BackgroundColor" Value="{Binding BindingContext.DayTodayBackgroundColor, Source={x:Reference This}}"/>
+                                        <Setter Property="TextColor" Value="{Binding BindingContext.DayTodayTextColor, Source={x:Reference This}}"/>
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.TodayStyle>
+
+                                <xc:DayView.SelectedStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewSelectedStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="BackgroundColor" Value="{Binding BindingContext.DaySelectedBackgroundColor, Source={x:Reference This}}"/>
+                                        <Setter Property="TextColor" Value="{Binding BindingContext.DaySelectedTextColor, Source={x:Reference This}}"/>
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.SelectedStyle>
+
+                                <xc:DayView.InvalidStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewInvalidStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="BackgroundColor" Value="{Binding BindingContext.DayInvalidBackgroundColor, Source={x:Reference This}}"/>
+                                        <Setter Property="TextColor" Value="{Binding BindingContext.DayInvalidTextColor, Source={x:Reference This}}"/>
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.InvalidStyle>
+
+                            </xc:DayView>
                         </Border>
                     </DataTemplate>
                 </xc:CalendarView.DayTemplate>

--- a/XCalendarMauiSample/Views/SelectionExamplePage.xaml
+++ b/XCalendarMauiSample/Views/SelectionExamplePage.xaml
@@ -69,18 +69,37 @@
                             </Border.StrokeShape>
 
                             <xc:DayView
-                                CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                CurrentMonthCommandParameter="{Binding DateTime}"
                                 DateTime="{Binding DateTime}"
+                                InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                                 IsCurrentMonth="{Binding IsCurrentMonth}"
                                 IsInvalid="{Binding IsInvalid}"
                                 IsSelected="{Binding IsSelected}"
                                 IsToday="{Binding IsToday}"
-                                SelectedCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                SelectedCommandParameter="{Binding DateTime}"
-                                Style="{StaticResource DefaultDayViewStyle}"
-                                TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                TodayCommandParameter="{Binding DateTime}"/>
+                                OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}">
+
+                                <xc:DayView.CurrentMonthStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.CurrentMonthStyle>
+
+                                <xc:DayView.TodayStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewTodayStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.TodayStyle>
+
+                                <xc:DayView.SelectedStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewSelectedStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.SelectedStyle>
+
+
+                            </xc:DayView>
                         </Border>
                     </DataTemplate>
                 </xc:CalendarView.DayTemplate>

--- a/XCalendarMauiSample/Views/SwipableCalendarExamplePage.xaml
+++ b/XCalendarMauiSample/Views/SwipableCalendarExamplePage.xaml
@@ -70,18 +70,36 @@
                                         </Border.StrokeShape>
 
                                         <xc:DayView
-                                            CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                            CurrentMonthCommandParameter="{Binding DateTime}"
                                             DateTime="{Binding DateTime}"
+                                            InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                                             IsCurrentMonth="{Binding IsCurrentMonth}"
                                             IsInvalid="{Binding IsInvalid}"
                                             IsSelected="{Binding IsSelected}"
                                             IsToday="{Binding IsToday}"
-                                            SelectedCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                            SelectedCommandParameter="{Binding DateTime}"
-                                            Style="{StaticResource DefaultDayViewStyle}"
-                                            TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                            TodayCommandParameter="{Binding DateTime}"/>
+                                            OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}">
+
+                                            <xc:DayView.CurrentMonthStyle>
+                                                <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">
+                                                    <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                                    <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                                </Style>
+                                            </xc:DayView.CurrentMonthStyle>
+
+                                            <xc:DayView.TodayStyle>
+                                                <Style BasedOn="{StaticResource DefaultDayViewTodayStyle}" TargetType="{x:Type xc:DayView}">
+                                                    <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                                    <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                                </Style>
+                                            </xc:DayView.TodayStyle>
+
+                                            <xc:DayView.SelectedStyle>
+                                                <Style BasedOn="{StaticResource DefaultDayViewSelectedStyle}" TargetType="{x:Type xc:DayView}">
+                                                    <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                                    <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                                </Style>
+                                            </xc:DayView.SelectedStyle>
+
+                                        </xc:DayView>
                                     </Border>
                                 </DataTemplate>
                             </xc:CalendarView.DayTemplate>

--- a/XCalendarMauiSample/Views/UsingDayViewExamplePage.xaml
+++ b/XCalendarMauiSample/Views/UsingDayViewExamplePage.xaml
@@ -57,19 +57,37 @@
                             </Border.StrokeShape>
 
                             <xc:DayView
-                                CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                CurrentMonthCommandParameter="{Binding DateTime}"
                                 DateTime="{Binding DateTime}"
                                 HeightRequest="47"
+                                InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                                 IsCurrentMonth="{Binding IsCurrentMonth}"
                                 IsInvalid="{Binding IsInvalid}"
                                 IsSelected="{Binding IsSelected}"
                                 IsToday="{Binding IsToday}"
-                                SelectedCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                SelectedCommandParameter="{Binding DateTime}"
-                                Style="{StaticResource DefaultDayViewStyle}"
-                                TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                                TodayCommandParameter="{Binding DateTime}"/>
+                                OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}">
+
+                                <xc:DayView.CurrentMonthStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.CurrentMonthStyle>
+
+                                <xc:DayView.TodayStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewTodayStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.TodayStyle>
+
+                                <xc:DayView.SelectedStyle>
+                                    <Style BasedOn="{StaticResource DefaultDayViewSelectedStyle}" TargetType="{x:Type xc:DayView}">
+                                        <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                                        <Setter Property="CommandParameter" Value="{Binding DateTime}"/>
+                                    </Style>
+                                </xc:DayView.SelectedStyle>
+
+                            </xc:DayView>
 
                         </Border>
                     </DataTemplate>
@@ -98,19 +116,37 @@
                 </Border.StrokeShape>
 
                 <xc:DayView
-                    CurrentMonthCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                    CurrentMonthCommandParameter="{Binding OutsideCalendarDay.DateTime}"
                     DateTime="{Binding OutsideCalendarDay.DateTime}"
                     HeightRequest="47"
+                    InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                     IsCurrentMonth="{Binding OutsideCalendarDay.IsCurrentMonth}"
                     IsInvalid="{Binding OutsideCalendarDay.IsInvalid}"
                     IsSelected="{Binding OutsideCalendarDay.IsSelected}"
                     IsToday="{Binding OutsideCalendarDay.IsToday}"
-                    SelectedCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                    SelectedCommandParameter="{Binding OutsideCalendarDay.DateTime}"
-                    Style="{StaticResource DefaultDayViewStyle}"
-                    TodayCommand="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"
-                    TodayCommandParameter="{Binding OutsideCalendarDay.DateTime}"/>
+                    OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}">
+
+                    <xc:DayView.CurrentMonthStyle>
+                        <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">
+                            <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                            <Setter Property="CommandParameter" Value="{Binding OutsideCalendarDay.DateTime}"/>
+                        </Style>
+                    </xc:DayView.CurrentMonthStyle>
+
+                    <xc:DayView.TodayStyle>
+                        <Style BasedOn="{StaticResource DefaultDayViewTodayStyle}" TargetType="{x:Type xc:DayView}">
+                            <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                            <Setter Property="CommandParameter" Value="{Binding OutsideCalendarDay.DateTime}"/>
+                        </Style>
+                    </xc:DayView.TodayStyle>
+
+                    <xc:DayView.SelectedStyle>
+                        <Style BasedOn="{StaticResource DefaultDayViewSelectedStyle}" TargetType="{x:Type xc:DayView}">
+                            <Setter Property="Command" Value="{Binding BindingContext.ChangeDateSelectionCommand, Source={x:Reference This}}"/>
+                            <Setter Property="CommandParameter" Value="{Binding OutsideCalendarDay.DateTime}"/>
+                        </Style>
+                    </xc:DayView.SelectedStyle>
+
+                </xc:DayView>
 
             </Border>
         </VerticalStackLayout>


### PR DESCRIPTION
This allows for easier and better customisation of a DayView in a specific `DayState`. Now, customisation has the same limitations as a `Style` instead of being restricted to what I choose to add (Previously just `TextColor`, `BackgroundColor`, `Command`, and `CommandParameter`).

This change also has a few positive side effects:
* Added "DefaultStyles" class containing default DayView styles for each `DayState`. This means you can easily reference them through the {x:Static} XAML markup extension instead of having to recreate them via trial and error or looking at source code.
* Improved CalendarView/MonthView initialisation and CalendarView navigation speed
* Fixes CalendarView navigation time being almost instant for 4-5 months, then taking slightly longer to navigate, then being almost instant again for the next 4-5 months. It should be faster and more consistent now.