### PR TITLE
Add property "AutoSetStyleBasedOnDayState" to DayView

### DIFF
--- a/XCalendar.Forms/Views/DayView.xaml.cs
+++ b/XCalendar.Forms/Views/DayView.xaml.cs
@@ -108,6 +108,11 @@ namespace XCalendar.Forms.Views
             get { return (object)GetValue(CommandParameterProperty); }
             set { SetValue(CommandParameterProperty, value); }
         }
+        public bool AutoSetStyleBasedOnDayState
+        {
+            get { return (bool)GetValue(AutoSetStyleBasedOnDayStateProperty); }
+            set { SetValue(AutoSetStyleBasedOnDayStateProperty, value); }
+        }
         public TextTransform TextTransform
         {
             get { return (TextTransform)GetValue(TextTransformProperty); }
@@ -221,6 +226,7 @@ namespace XCalendar.Forms.Views
         public static readonly BindableProperty TextTypeProperty = BindableProperty.Create(nameof(TextType), typeof(TextType), typeof(DayView), Label.TextTypeProperty.DefaultValue);
         public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(DayView), Label.TextColorProperty.DefaultValue);
         public static readonly BindableProperty VerticalTextAlignmentProperty = BindableProperty.Create(nameof(VerticalTextAlignment), typeof(TextAlignment), typeof(DayView), TextAlignment.Center);
+        public static readonly BindableProperty AutoSetStyleBasedOnDayStateProperty = BindableProperty.Create(nameof(AutoSetStyleBasedOnDayState), typeof(bool), typeof(DayView), true, propertyChanged: AutoSetStyleBasedOnDayStatePropertyChanged);
         #endregion
 
         #endregion
@@ -266,30 +272,33 @@ namespace XCalendar.Forms.Views
         }
         public virtual void UpdateView()
         {
-            switch (DayState)
+            if (AutoSetStyleBasedOnDayState)
             {
-                case DayState.CurrentMonth:
-                    Style = CurrentMonthStyle;
-                    break;
+                switch (DayState)
+                {
+                    case DayState.CurrentMonth:
+                        Style = CurrentMonthStyle;
+                        break;
 
-                case DayState.OtherMonth:
-                    Style = OtherMonthStyle;
-                    break;
+                    case DayState.OtherMonth:
+                        Style = OtherMonthStyle;
+                        break;
 
-                case DayState.Today:
-                    Style = TodayStyle;
-                    break;
+                    case DayState.Today:
+                        Style = TodayStyle;
+                        break;
 
-                case DayState.Selected:
-                    Style = SelectedStyle;
-                    break;
+                    case DayState.Selected:
+                        Style = SelectedStyle;
+                        break;
 
-                case DayState.Invalid:
-                    Style = InvalidStyle;
-                    break;
+                    case DayState.Invalid:
+                        Style = InvalidStyle;
+                        break;
 
-                default:
-                    throw new NotImplementedException($"{nameof(DayState)} '{DayState}' is not implemented.");
+                    default:
+                        throw new NotImplementedException($"{nameof(DayState)} '{DayState}' is not implemented.");
+                }
             }
         }
 
@@ -401,6 +410,16 @@ namespace XCalendar.Forms.Views
             DayView control = (DayView)bindable;
 
             control.UpdateView();
+        }
+        private static void AutoSetStyleBasedOnDayStatePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            DayView control = (DayView)bindable;
+            bool newAutoSetStyleBasedOnDayState = (bool)newValue;
+
+            if (newAutoSetStyleBasedOnDayState)
+            {
+                control.UpdateView();
+            }
         }
         private static object CoerceDayState(BindableObject bindable, object value)
         {

--- a/XCalendar.Maui/Views/DayView.xaml.cs
+++ b/XCalendar.Maui/Views/DayView.xaml.cs
@@ -104,6 +104,11 @@ namespace XCalendar.Maui.Views
             get { return (object)GetValue(CommandParameterProperty); }
             set { SetValue(CommandParameterProperty, value); }
         }
+        public bool AutoSetStyleBasedOnDayState
+        {
+            get { return (bool)GetValue(AutoSetStyleBasedOnDayStateProperty); }
+            set { SetValue(AutoSetStyleBasedOnDayStateProperty, value); }
+        }
         public TextTransform TextTransform
         {
             get { return (TextTransform)GetValue(TextTransformProperty); }
@@ -216,6 +221,7 @@ namespace XCalendar.Maui.Views
         public static readonly BindableProperty TextTypeProperty = BindableProperty.Create(nameof(TextType), typeof(TextType), typeof(DayView), Label.TextTypeProperty.DefaultValue);
         public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(DayView), Label.TextColorProperty.DefaultValue);
         public static readonly BindableProperty VerticalTextAlignmentProperty = BindableProperty.Create(nameof(VerticalTextAlignment), typeof(TextAlignment), typeof(DayView), TextAlignment.Center);
+        public static readonly BindableProperty AutoSetStyleBasedOnDayStateProperty = BindableProperty.Create(nameof(AutoSetStyleBasedOnDayState), typeof(bool), typeof(DayView), true, propertyChanged: AutoSetStyleBasedOnDayStatePropertyChanged);
         #endregion
 
         #endregion
@@ -261,30 +267,33 @@ namespace XCalendar.Maui.Views
         }
         public virtual void UpdateView()
         {
-            switch (DayState)
+            if (AutoSetStyleBasedOnDayState)
             {
-                case DayState.CurrentMonth:
-                    Style = CurrentMonthStyle;
-                    break;
+                switch (DayState)
+                {
+                    case DayState.CurrentMonth:
+                        Style = CurrentMonthStyle;
+                        break;
 
-                case DayState.OtherMonth:
-                    Style = OtherMonthStyle;
-                    break;
+                    case DayState.OtherMonth:
+                        Style = OtherMonthStyle;
+                        break;
 
-                case DayState.Today:
-                    Style = TodayStyle;
-                    break;
+                    case DayState.Today:
+                        Style = TodayStyle;
+                        break;
 
-                case DayState.Selected:
-                    Style = SelectedStyle;
-                    break;
+                    case DayState.Selected:
+                        Style = SelectedStyle;
+                        break;
 
-                case DayState.Invalid:
-                    Style = InvalidStyle;
-                    break;
+                    case DayState.Invalid:
+                        Style = InvalidStyle;
+                        break;
 
-                default:
-                    throw new NotImplementedException($"{nameof(DayState)} '{DayState}' is not implemented.");
+                    default:
+                        throw new NotImplementedException($"{nameof(DayState)} '{DayState}' is not implemented.");
+                }
             }
         }
 
@@ -396,6 +405,16 @@ namespace XCalendar.Maui.Views
             DayView control = (DayView)bindable;
 
             control.UpdateView();
+        }
+        private static void AutoSetStyleBasedOnDayStatePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            DayView control = (DayView)bindable;
+            bool newAutoSetStyleBasedOnDayState = (bool)newValue;
+
+            if (newAutoSetStyleBasedOnDayState)
+            {
+                control.UpdateView();
+            }
         }
         private static object CoerceDayState(BindableObject bindable, object value)
         {

--- a/XCalendarFormsSample/XCalendarFormsSample/ViewModels/PlaygroundViewModel.cs
+++ b/XCalendarFormsSample/XCalendarFormsSample/ViewModels/PlaygroundViewModel.cs
@@ -43,6 +43,7 @@ namespace XCalendarFormsSample.ViewModels
         public double NavigationHeightRequest { get; set; } = 50;
         public double DayHeightRequest { get; set; } = 45;
         public double DayWidthRequest { get; set; } = 45;
+        public bool DayAutoSetStyleBasedOnDayState { get; set; } = true;
         public int ForwardsNavigationAmount { get; set; } = 1;
         public int BackwardsNavigationAmount { get; set; } = -1;
         public Color CalendarBackgroundColor { get; set; } = (Color)Application.Current.Resources["CalendarBackgroundColor"];

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/PlaygroundPage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/PlaygroundPage.xaml
@@ -613,6 +613,19 @@
                             Grid.Column="0"
                             FontSize="{StaticResource SmallFontSize}"
                             HorizontalTextAlignment="Center"
+                            Text="AutoSetStyleBasedOnDayState"
+                            VerticalTextAlignment="Center"/>
+                        <Switch
+                            Grid.Column="1"
+                            HorizontalOptions="Center"
+                            IsToggled="{Binding DayAutoSetStyleBasedOnDayState}"/>
+                    </Grid>
+
+                    <Grid>
+                        <Label
+                            Grid.Column="0"
+                            FontSize="{StaticResource SmallFontSize}"
+                            HorizontalTextAlignment="Center"
                             Text="WidthRequest"
                             VerticalTextAlignment="Center"/>
                         <Editor
@@ -954,6 +967,7 @@
                                     HorizontalOptions="Center"
                                     VerticalOptions="Center">
                                     <xc:DayView
+                                        AutoSetStyleBasedOnDayState="{Binding BindingContext.DayAutoSetStyleBasedOnDayState, Source={x:Reference This}}"
                                         DateTime="{Binding DateTime}"
                                         HeightRequest="{Binding BindingContext.DayHeightRequest, Source={x:Reference This}}"
                                         IsCurrentMonth="{Binding IsCurrentMonth}"

--- a/XCalendarMauiSample/ViewModels/PlaygroundViewModel.cs
+++ b/XCalendarMauiSample/ViewModels/PlaygroundViewModel.cs
@@ -39,6 +39,7 @@ namespace XCalendarMauiSample.ViewModels
         public double NavigationHeightRequest { get; set; } = 50;
         public double DayHeightRequest { get; set; } = 45;
         public double DayWidthRequest { get; set; } = 45;
+        public bool DayAutoSetStyleBasedOnDayState { get; set; } = true;
         public int ForwardsNavigationAmount { get; set; } = 1;
         public int BackwardsNavigationAmount { get; set; } = -1;
         public Color CalendarBackgroundColor { get; set; } = (Color)Application.Current.Resources["CalendarBackgroundColor"];

--- a/XCalendarMauiSample/Views/PlaygroundPage.xaml
+++ b/XCalendarMauiSample/Views/PlaygroundPage.xaml
@@ -625,6 +625,19 @@
                         Grid.Column="0"
                         FontSize="{StaticResource SmallFontSize}"
                         HorizontalTextAlignment="Center"
+                        Text="AutoSetStyleBasedOnDayState"
+                        VerticalTextAlignment="Center"/>
+                    <Switch
+                        Grid.Column="1"
+                        HorizontalOptions="Center"
+                        IsToggled="{Binding DayAutoSetStyleBasedOnDayState}"/>
+                </Grid>
+
+                <Grid>
+                    <Label
+                        Grid.Column="0"
+                        FontSize="{StaticResource SmallFontSize}"
+                        HorizontalTextAlignment="Center"
                         Text="WidthRequest"
                         VerticalTextAlignment="Center"/>
                     <Editor
@@ -998,6 +1011,7 @@
                             </Border.StrokeShape>
 
                             <xc:DayView
+                                AutoSetStyleBasedOnDayState="{Binding BindingContext.DayAutoSetStyleBasedOnDayState, Source={x:Reference This}}"
                                 DateTime="{Binding DateTime}"
                                 IsCurrentMonth="{Binding IsCurrentMonth}"
                                 IsInvalid="{Binding IsInvalid}"


### PR DESCRIPTION
If true, automatically sets the DayView 's `Style` to the style matching the current `DayState`. Otherwise, does nothing.

This is useful for when the developer wants to manually set/manage the DayView's `Style`.