### PR TITLE
Change DayView WidthRequest and HeightRequest defaults and how they are set

### DIFF
--- a/XCalendar.Forms/Styles/DefaultStyles.cs
+++ b/XCalendar.Forms/Styles/DefaultStyles.cs
@@ -19,6 +19,7 @@ namespace XCalendar.Forms.Styles
             Style style = new Style(typeof(DayView)) { CanCascade = true };
             style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Color.Transparent });
             style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Color.Black });
+            style.Setters.Add(new Setter() { Property = VisualElement.HeightRequestProperty, Value = 45d });
 
             return style;
         }
@@ -27,6 +28,7 @@ namespace XCalendar.Forms.Styles
             Style style = new Style(typeof(DayView)) { CanCascade = true };
             style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Color.Transparent });
             style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Color.FromHex("#A0A0A0") });
+            style.Setters.Add(new Setter() { Property = VisualElement.HeightRequestProperty, Value = 45d });
 
             return style;
         }
@@ -35,6 +37,7 @@ namespace XCalendar.Forms.Styles
             Style style = new Style(typeof(DayView)) { CanCascade = true };
             style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Color.Transparent });
             style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Color.Black });
+            style.Setters.Add(new Setter() { Property = VisualElement.HeightRequestProperty, Value = 45d });
 
             return style;
         }
@@ -43,6 +46,7 @@ namespace XCalendar.Forms.Styles
             Style style = new Style(typeof(DayView)) { CanCascade = true };
             style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Color.FromHex("#E00000") });
             style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Color.Black });
+            style.Setters.Add(new Setter() { Property = VisualElement.HeightRequestProperty, Value = 45d });
 
             return style;
         }
@@ -51,6 +55,7 @@ namespace XCalendar.Forms.Styles
             Style style = new Style(typeof(DayView)) { CanCascade = true };
             style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Color.Transparent });
             style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Color.FromHex("#FFA0A0") });
+            style.Setters.Add(new Setter() { Property = VisualElement.HeightRequestProperty, Value = 45d });
 
             return style;
         }

--- a/XCalendar.Forms/Views/DayView.xaml
+++ b/XCalendar.Forms/Views/DayView.xaml
@@ -5,9 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:xc="clr-namespace:XCalendar.Forms.Views"
     x:Name="DayView_Unique"
-    x:DataType="{x:Type xc:DayView}"
-    HeightRequest="45"
-    WidthRequest="45">
+    x:DataType="{x:Type xc:DayView}">
 
     <Label
         CharacterSpacing="{Binding CharacterSpacing, Source={x:Reference DayView_Unique}}"

--- a/XCalendar.Maui/Styles/DefaultStyles.cs
+++ b/XCalendar.Maui/Styles/DefaultStyles.cs
@@ -18,6 +18,7 @@ namespace XCalendar.Maui.Styles
             Style style = new Style(typeof(DayView)) { CanCascade = true };
             style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Colors.Transparent });
             style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Colors.Black });
+            style.Setters.Add(new Setter() { Property = VisualElement.HeightRequestProperty, Value = 45d });
 
             return style;
         }
@@ -26,6 +27,7 @@ namespace XCalendar.Maui.Styles
             Style style = new Style(typeof(DayView)) { CanCascade = true };
             style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Colors.Transparent });
             style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Color.FromArgb("#A0A0A0") });
+            style.Setters.Add(new Setter() { Property = VisualElement.HeightRequestProperty, Value = 45d });
 
             return style;
         }
@@ -34,6 +36,7 @@ namespace XCalendar.Maui.Styles
             Style style = new Style(typeof(DayView)) { CanCascade = true };
             style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Colors.Transparent });
             style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Colors.Black });
+            style.Setters.Add(new Setter() { Property = VisualElement.HeightRequestProperty, Value = 45d });
 
             return style;
         }
@@ -42,6 +45,7 @@ namespace XCalendar.Maui.Styles
             Style style = new Style(typeof(DayView)) { CanCascade = true };
             style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Color.FromArgb("#E00000") });
             style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Colors.Black });
+            style.Setters.Add(new Setter() { Property = VisualElement.HeightRequestProperty, Value = 45d });
 
             return style;
         }
@@ -50,6 +54,7 @@ namespace XCalendar.Maui.Styles
             Style style = new Style(typeof(DayView)) { CanCascade = true };
             style.Setters.Add(new Setter() { Property = VisualElement.BackgroundColorProperty, Value = Colors.Transparent });
             style.Setters.Add(new Setter() { Property = DayView.TextColorProperty, Value = Color.FromArgb("#FFA0A0") });
+            style.Setters.Add(new Setter() { Property = VisualElement.HeightRequestProperty, Value = 45d });
 
             return style;
         }

--- a/XCalendar.Maui/Views/DayView.xaml
+++ b/XCalendar.Maui/Views/DayView.xaml
@@ -5,9 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:xc="clr-namespace:XCalendar.Maui.Views"
     x:Name="DayView_Unique"
-    x:DataType="{x:Type xc:DayView}"
-    HeightRequest="45"
-    WidthRequest="45">
+    x:DataType="{x:Type xc:DayView}">
 
     <Label
         CharacterSpacing="{Binding CharacterSpacing, Source={x:Reference DayView_Unique}}"

--- a/XCalendar.Maui/Views/DaysView.xaml
+++ b/XCalendar.Maui/Views/DaysView.xaml
@@ -23,14 +23,10 @@
                 <Setter Property="ItemTemplate">
                     <Setter.Value>
                         <DataTemplate x:DataType="{x:Type xcInterfaces:ICalendarDay}">
-                            <Border
-                                Margin="2.5"
-                                BackgroundColor="Transparent"
-                                HeightRequest="45"
-                                WidthRequest="45">
+                            <Border Margin="2.5" BackgroundColor="Transparent">
 
                                 <Border.StrokeShape>
-                                    <Ellipse/>
+                                    <RoundRectangle CornerRadius="100"/>
                                 </Border.StrokeShape>
 
                                 <xc:DayView

--- a/XCalendarFormsSample/XCalendarFormsSample/App.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/App.xaml
@@ -42,6 +42,7 @@
 
         <Style x:Key="DefaultCalendarViewStyle" TargetType="{x:Type xc:CalendarView}">
             <Setter Property="BackgroundColor" Value="{StaticResource CalendarBackgroundColor}"/>
+            <Setter Property="DaysViewHeightRequest" Value="320"/>
         </Style>
 
         <Style x:Key="DefaultNavigationViewStyle" TargetType="{x:Type xc:NavigationView}">

--- a/XCalendarFormsSample/XCalendarFormsSample/ViewModels/PlaygroundViewModel.cs
+++ b/XCalendarFormsSample/XCalendarFormsSample/ViewModels/PlaygroundViewModel.cs
@@ -38,11 +38,11 @@ namespace XCalendarFormsSample.ViewModels
         };
         public string NavigationTimeUnit { get; set; } = "Month";
         public bool CalendarIsVisible { get; set; } = true;
-        public double DaysViewHeightRequest { get; set; } = 300;
+        public double DaysViewHeightRequest { get; set; } = 320;
         public double DayNamesHeightRequest { get; set; } = 25;
         public double NavigationHeightRequest { get; set; } = 50;
         public double DayHeightRequest { get; set; } = 45;
-        public double DayWidthRequest { get; set; } = 45;
+        public double DayWidthRequest { get; set; } = -1;
         public bool DayAutoSetStyleBasedOnDayState { get; set; } = true;
         public int ForwardsNavigationAmount { get; set; } = 1;
         public int BackwardsNavigationAmount { get; set; } = -1;

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/ConnectingSelectedDaysExamplePage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/ConnectingSelectedDaysExamplePage.xaml
@@ -59,6 +59,7 @@
                         <ContentView>
                             <xc:DayView
                                 DateTime="{Binding DateTime}"
+                                HeightRequest="52.5"
                                 InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                                 IsCurrentMonth="{Binding IsCurrentMonth}"
                                 IsInvalid="{Binding IsInvalid}"

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/CustomisingADayExamplePage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/CustomisingADayExamplePage.xaml
@@ -17,7 +17,6 @@
             BackwardsArrowCommand="{Binding NavigateCalendarCommand}"
             Days="{Binding Calendar.Days}"
             DaysOfWeek="{Binding Calendar.DayNamesOrder}"
-            DaysViewHeightRequest="320"
             ForwardsArrowCommand="{Binding NavigateCalendarCommand}"
             NavigatedDate="{Binding Calendar.NavigatedDate}"
             Style="{StaticResource DefaultCalendarViewStyle}">

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/EventCalendarExamplePage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/EventCalendarExamplePage.xaml
@@ -84,7 +84,7 @@
                                 HasShadow="False">
                                 <xc:DayView
                                     DateTime="{Binding DateTime}"
-                                    HeightRequest="41"
+                                    HeightRequest="42"
                                     InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                                     IsCurrentMonth="{Binding IsCurrentMonth}"
                                     IsInvalid="{Binding IsInvalid}"

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/PlaygroundPage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/PlaygroundPage.xaml
@@ -963,9 +963,7 @@
                                     Margin="2.5"
                                     Padding="0"
                                     CornerRadius="100"
-                                    HasShadow="False"
-                                    HorizontalOptions="Center"
-                                    VerticalOptions="Center">
+                                    HasShadow="False">
                                     <xc:DayView
                                         AutoSetStyleBasedOnDayState="{Binding BindingContext.DayAutoSetStyleBasedOnDayState, Source={x:Reference This}}"
                                         DateTime="{Binding DateTime}"

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/SwipableCalendarExamplePage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/SwipableCalendarExamplePage.xaml
@@ -24,7 +24,7 @@
         <CarouselView
             Grid.Row="0"
             CurrentItemChangedCommand="{Binding CurrentPageCalendarChangedCommand}"
-            HeightRequest="382.5"
+            HeightRequest="400"
             ItemsSource="{Binding Calendars}"
             Position="{Binding CurrentPageCalendarPosition}">
 

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/UsingDayViewExamplePage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/UsingDayViewExamplePage.xaml
@@ -18,7 +18,6 @@
                 BackwardsArrowCommand="{Binding NavigateCalendarCommand}"
                 Days="{Binding Calendar.Days}"
                 DaysOfWeek="{Binding Calendar.DayNamesOrder}"
-                DaysViewHeightRequest="330"
                 ForwardsArrowCommand="{Binding NavigateCalendarCommand}"
                 NavigatedDate="{Binding Calendar.NavigatedDate}"
                 Style="{StaticResource DefaultCalendarViewStyle}">
@@ -54,7 +53,6 @@
                                 HasShadow="False">
                                 <xc:DayView
                                     DateTime="{Binding DateTime}"
-                                    HeightRequest="47"
                                     InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                                     IsCurrentMonth="{Binding IsCurrentMonth}"
                                     IsInvalid="{Binding IsInvalid}"
@@ -106,17 +104,17 @@
                 BackgroundColor="Transparent"
                 CornerRadius="100"
                 HasShadow="False"
-                HeightRequest="47"
-                HorizontalOptions="Center"
-                WidthRequest="47">
+                HorizontalOptions="Center">
                 <xc:DayView
                     DateTime="{Binding OutsideCalendarDay.DateTime}"
+                    HeightRequest="45"
                     InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                     IsCurrentMonth="{Binding OutsideCalendarDay.IsCurrentMonth}"
                     IsInvalid="{Binding OutsideCalendarDay.IsInvalid}"
                     IsSelected="{Binding OutsideCalendarDay.IsSelected}"
                     IsToday="{Binding OutsideCalendarDay.IsToday}"
-                    OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}">
+                    OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}"
+                    WidthRequest="45">
 
                     <xc:DayView.CurrentMonthStyle>
                         <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">

--- a/XCalendarMauiSample/App.xaml
+++ b/XCalendarMauiSample/App.xaml
@@ -43,6 +43,7 @@
 
         <Style x:Key="DefaultCalendarViewStyle" TargetType="{x:Type xc:CalendarView}">
             <Setter Property="BackgroundColor" Value="{StaticResource CalendarBackgroundColor}"/>
+            <Setter Property="DaysViewHeightRequest" Value="320"/>
         </Style>
 
         <Style x:Key="DefaultNavigationViewStyle" TargetType="{x:Type xc:NavigationView}">

--- a/XCalendarMauiSample/ViewModels/PlaygroundViewModel.cs
+++ b/XCalendarMauiSample/ViewModels/PlaygroundViewModel.cs
@@ -34,11 +34,11 @@ namespace XCalendarMauiSample.ViewModels
         };
         public string NavigationTimeUnit { get; set; } = "Month";
         public bool CalendarIsVisible { get; set; } = true;
-        public double DaysViewHeightRequest { get; set; } = 300;
+        public double DaysViewHeightRequest { get; set; } = 320;
         public double DayNamesHeightRequest { get; set; } = 25;
         public double NavigationHeightRequest { get; set; } = 50;
         public double DayHeightRequest { get; set; } = 45;
-        public double DayWidthRequest { get; set; } = 45;
+        public double DayWidthRequest { get; set; } = -1;
         public bool DayAutoSetStyleBasedOnDayState { get; set; } = true;
         public int ForwardsNavigationAmount { get; set; } = 1;
         public int BackwardsNavigationAmount { get; set; } = -1;

--- a/XCalendarMauiSample/Views/ConnectingSelectedDaysExamplePage.xaml
+++ b/XCalendarMauiSample/Views/ConnectingSelectedDaysExamplePage.xaml
@@ -60,15 +60,13 @@
                     <DataTemplate x:DataType="{x:Type Models:ConnectableDay}">
                         <xc:DayView
                             DateTime="{Binding DateTime}"
-                            HorizontalOptions="FillAndExpand"
-                            InvalidStyle="{StaticResource DefaultDayViewOtherMonthStyle}"
+                            HeightRequest="52.5"
+                            InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                             IsCurrentMonth="{Binding IsCurrentMonth}"
                             IsInvalid="{Binding IsInvalid}"
                             IsSelected="{Binding IsSelected}"
                             IsToday="{Binding IsToday}"
-                            OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}"
-                            VerticalOptions="FillAndExpand"
-                            WidthRequest="-1">
+                            OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}">
 
                             <xc:DayView.CurrentMonthStyle>
                                 <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">

--- a/XCalendarMauiSample/Views/CustomisingADayExamplePage.xaml
+++ b/XCalendarMauiSample/Views/CustomisingADayExamplePage.xaml
@@ -17,7 +17,6 @@
             BackwardsArrowCommand="{Binding NavigateCalendarCommand}"
             Days="{Binding Calendar.Days}"
             DaysOfWeek="{Binding Calendar.DayNamesOrder}"
-            DaysViewHeightRequest="320"
             ForwardsArrowCommand="{Binding NavigateCalendarCommand}"
             NavigatedDate="{Binding Calendar.NavigatedDate}"
             Style="{StaticResource DefaultCalendarViewStyle}">
@@ -44,14 +43,10 @@
 
             <xc:CalendarView.DayTemplate>
                 <DataTemplate x:DataType="{x:Type xcModels:CalendarDay}">
-                    <Border
-                        Margin="2.5"
-                        BackgroundColor="Transparent"
-                        HeightRequest="45"
-                        WidthRequest="45">
+                    <Border Margin="2.5" BackgroundColor="Transparent">
 
                         <Border.StrokeShape>
-                            <Ellipse/>
+                            <RoundRectangle CornerRadius="100"/>
                         </Border.StrokeShape>
 
                         <xc:DayView

--- a/XCalendarMauiSample/Views/EventCalendarExamplePage.xaml
+++ b/XCalendarMauiSample/Views/EventCalendarExamplePage.xaml
@@ -76,18 +76,15 @@
 
                 <xc:CalendarView.DayTemplate>
                     <DataTemplate x:DataType="{x:Type Models:EventDay}">
-                        <Border
-                            Margin="2.5"
-                            BackgroundColor="Transparent"
-                            HeightRequest="45"
-                            WidthRequest="45">
+                        <Border Margin="2.5" BackgroundColor="Transparent">
 
                             <Border.StrokeShape>
-                                <Ellipse/>
+                                <RoundRectangle CornerRadius="100"/>
                             </Border.StrokeShape>
 
                             <xc:DayView
                                 DateTime="{Binding DateTime}"
+                                HeightRequest="42"
                                 InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                                 IsCurrentMonth="{Binding IsCurrentMonth}"
                                 IsInvalid="{Binding IsInvalid}"

--- a/XCalendarMauiSample/Views/PlaygroundPage.xaml
+++ b/XCalendarMauiSample/Views/PlaygroundPage.xaml
@@ -1000,23 +1000,21 @@
 
                 <xc:CalendarView.DayTemplate>
                     <DataTemplate x:DataType="{x:Type xcModels:CalendarDay}">
-                        <Border
-                            Margin="2.5"
-                            BackgroundColor="Transparent"
-                            HeightRequest="{Binding BindingContext.DayHeightRequest, Source={x:Reference This}}"
-                            WidthRequest="{Binding BindingContext.DayWidthRequest, Source={x:Reference This}}">
+                        <Border Margin="2.5" BackgroundColor="Transparent">
 
                             <Border.StrokeShape>
-                                <Ellipse/>
+                                <RoundRectangle CornerRadius="100"/>
                             </Border.StrokeShape>
 
                             <xc:DayView
                                 AutoSetStyleBasedOnDayState="{Binding BindingContext.DayAutoSetStyleBasedOnDayState, Source={x:Reference This}}"
                                 DateTime="{Binding DateTime}"
+                                HeightRequest="{Binding BindingContext.DayHeightRequest, Source={x:Reference This}}"
                                 IsCurrentMonth="{Binding IsCurrentMonth}"
                                 IsInvalid="{Binding IsInvalid}"
                                 IsSelected="{Binding IsSelected}"
-                                IsToday="{Binding IsToday}">
+                                IsToday="{Binding IsToday}"
+                                WidthRequest="{Binding BindingContext.DayWidthRequest, Source={x:Reference This}}">
 
                                 <xc:DayView.CurrentMonthStyle>
                                     <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">

--- a/XCalendarMauiSample/Views/SelectionExamplePage.xaml
+++ b/XCalendarMauiSample/Views/SelectionExamplePage.xaml
@@ -58,14 +58,10 @@
                 <!--  Not Required, used only for styling.  -->
                 <xc:CalendarView.DayTemplate>
                     <DataTemplate x:DataType="{x:Type xcInterfaces:ICalendarDay}">
-                        <Border
-                            Margin="2.5"
-                            BackgroundColor="Transparent"
-                            HeightRequest="45"
-                            WidthRequest="45">
+                        <Border Margin="2.5" BackgroundColor="Transparent">
 
                             <Border.StrokeShape>
-                                <Ellipse/>
+                                <RoundRectangle CornerRadius="100"/>
                             </Border.StrokeShape>
 
                             <xc:DayView

--- a/XCalendarMauiSample/Views/SwipableCalendarExamplePage.xaml
+++ b/XCalendarMauiSample/Views/SwipableCalendarExamplePage.xaml
@@ -24,7 +24,7 @@
         <CarouselView
             Grid.Row="0"
             CurrentItemChangedCommand="{Binding CurrentPageCalendarChangedCommand}"
-            HeightRequest="382.5"
+            HeightRequest="400"
             ItemsSource="{Binding Calendars}"
             Position="{Binding CurrentPageCalendarPosition}">
 
@@ -59,14 +59,10 @@
 
                             <xc:CalendarView.DayTemplate>
                                 <DataTemplate x:DataType="{x:Type xcModels:CalendarDay}">
-                                    <Border
-                                        Margin="2.5"
-                                        BackgroundColor="Transparent"
-                                        HeightRequest="45"
-                                        WidthRequest="45">
+                                    <Border Margin="2.5" BackgroundColor="Transparent">
 
                                         <Border.StrokeShape>
-                                            <Ellipse/>
+                                            <RoundRectangle CornerRadius="100"/>
                                         </Border.StrokeShape>
 
                                         <xc:DayView

--- a/XCalendarMauiSample/Views/UsingDayViewExamplePage.xaml
+++ b/XCalendarMauiSample/Views/UsingDayViewExamplePage.xaml
@@ -18,7 +18,6 @@
                 BackwardsArrowCommand="{Binding NavigateCalendarCommand}"
                 Days="{Binding Calendar.Days}"
                 DaysOfWeek="{Binding Calendar.DayNamesOrder}"
-                DaysViewHeightRequest="330"
                 ForwardsArrowCommand="{Binding NavigateCalendarCommand}"
                 NavigatedDate="{Binding Calendar.NavigatedDate}"
                 Style="{StaticResource DefaultCalendarViewStyle}">
@@ -46,19 +45,14 @@
                 <xc:CalendarView.DayTemplate>
                     <DataTemplate x:DataType="{x:Type xcModels:CalendarDay}">
                         <!--  Inside the CalendarView  -->
-                        <Border
-                            Margin="2.5"
-                            BackgroundColor="Transparent"
-                            HeightRequest="45"
-                            WidthRequest="45">
+                        <Border Margin="2.5" BackgroundColor="Transparent">
 
                             <Border.StrokeShape>
-                                <Ellipse/>
+                                <RoundRectangle CornerRadius="100"/>
                             </Border.StrokeShape>
 
                             <xc:DayView
                                 DateTime="{Binding DateTime}"
-                                HeightRequest="47"
                                 InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                                 IsCurrentMonth="{Binding IsCurrentMonth}"
                                 IsInvalid="{Binding IsInvalid}"
@@ -107,9 +101,7 @@
             <Border
                 Margin="0,5,0,5"
                 BackgroundColor="Transparent"
-                HeightRequest="47"
-                HorizontalOptions="Center"
-                WidthRequest="47">
+                HorizontalOptions="Center">
 
                 <Border.StrokeShape>
                     <Ellipse/>
@@ -117,13 +109,14 @@
 
                 <xc:DayView
                     DateTime="{Binding OutsideCalendarDay.DateTime}"
-                    HeightRequest="47"
+                    HeightRequest="45"
                     InvalidStyle="{StaticResource DefaultDayViewInvalidStyle}"
                     IsCurrentMonth="{Binding OutsideCalendarDay.IsCurrentMonth}"
                     IsInvalid="{Binding OutsideCalendarDay.IsInvalid}"
                     IsSelected="{Binding OutsideCalendarDay.IsSelected}"
                     IsToday="{Binding OutsideCalendarDay.IsToday}"
-                    OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}">
+                    OtherMonthStyle="{StaticResource DefaultDayViewOtherMonthStyle}"
+                    WidthRequest="45">
 
                     <xc:DayView.CurrentMonthStyle>
                         <Style BasedOn="{StaticResource DefaultDayViewCurrentMonthStyle}" TargetType="{x:Type xc:DayView}">


### PR DESCRIPTION
WidthRequest and HeightRequest used to be set in the custom control itself. As a result, styles that set the WidthRequest or HeightRequest of the DayView would be overriden by these default values. Now they are set using the styles defined in the "DefaultStyles" class.

The WidthRequest default was changed from "45" to "-1". "-1" means all available horizontal space will be filled.