### PR TITLE
 Fix DuolingoStreakCalendar example not joining the streak background across OtherMonth days

### DIFF
--- a/XCalendarFormsSample/XCalendarFormsSample/ViewModels/DuolingoStreakCalendarExampleViewModel.cs
+++ b/XCalendarFormsSample/XCalendarFormsSample/ViewModels/DuolingoStreakCalendarExampleViewModel.cs
@@ -89,13 +89,38 @@ namespace XCalendarFormsSample.ViewModels
                 }
             }
 
+            DateTime firstDayOfMonth = Calendar.NavigatedDate.FirstDayOfMonth();
+            DateTime lastDayOfMonth = Calendar.NavigatedDate.LastDayOfMonth();
+            DateTime lastDayOfPreviousMonth = firstDayOfMonth.AddDays(-1);
+            DateTime firstDayOfNextMonth = lastDayOfMonth.AddDays(1);
+
             for (int i = 0; i < Calendar.Days.Count; i++)
             {
                 DuolingoDay day = Calendar.Days[i];
 
-                day.IsInsidePerfectWeek = datesInsidePerfectWeek.Any(x => x.Date == day.DateTime.Date);
-                day.DailyGoalAchieved = DatesWhenGoalWasAchieved.Any(x => x.Date == day.DateTime.Date);
-                day.StreakFreezeUsed = DatesWhenStreakFreezeWasUsed.Any(x => x.Date == day.DateTime.Date);
+                //Days outside the month should be connected if the first day of the current month connects to the last day of the previous month or
+                //the last day of the current month connects to the first day of the next month.
+
+                if (day.DateTime.Date < firstDayOfMonth.Date)
+                {
+                    day.IsInsidePerfectWeek = datesInsidePerfectWeek.Any(x => x.Date == firstDayOfMonth.Date) && datesInsidePerfectWeek.Any(x => x.Date == lastDayOfPreviousMonth.Date);
+                    day.DailyGoalAchieved = (DatesWhenGoalWasAchieved.Any(x => x.Date == firstDayOfMonth.Date) || DatesWhenStreakFreezeWasUsed.Any(x => x.Date == firstDayOfMonth.Date))
+                        && (DatesWhenGoalWasAchieved.Any(x => x.Date == lastDayOfPreviousMonth.Date) || DatesWhenStreakFreezeWasUsed.Any(x => x.Date == lastDayOfPreviousMonth.Date));
+                    day.StreakFreezeUsed = false;
+                }
+                else if (day.DateTime.Date > lastDayOfMonth.Date)
+                {
+                    day.IsInsidePerfectWeek = datesInsidePerfectWeek.Any(x => x.Date == lastDayOfMonth.Date) && datesInsidePerfectWeek.Any(x => x.Date == firstDayOfNextMonth.Date);
+                    day.DailyGoalAchieved = (DatesWhenGoalWasAchieved.Any(x => x.Date == lastDayOfMonth.Date) || DatesWhenStreakFreezeWasUsed.Any(x => x.Date == lastDayOfMonth.Date))
+                        && (DatesWhenGoalWasAchieved.Any(x => x.Date == firstDayOfNextMonth.Date) || DatesWhenStreakFreezeWasUsed.Any(x => x.Date == firstDayOfNextMonth.Date));
+                    day.StreakFreezeUsed = false;
+                }
+                else
+                {
+                    day.IsInsidePerfectWeek = datesInsidePerfectWeek.Any(x => x.Date == day.DateTime.Date);
+                    day.DailyGoalAchieved = DatesWhenGoalWasAchieved.Any(x => x.Date == day.DateTime.Date);
+                    day.StreakFreezeUsed = DatesWhenStreakFreezeWasUsed.Any(x => x.Date == day.DateTime.Date);
+                }
             }
 
             for (int i = 0; i < Calendar.Days.Count; i++)

--- a/XCalendarFormsSample/XCalendarFormsSample/ViewModels/ExamplesViewModel.cs
+++ b/XCalendarFormsSample/XCalendarFormsSample/ViewModels/ExamplesViewModel.cs
@@ -57,8 +57,8 @@ namespace XCalendarFormsSample.ViewModels
             new Example()
             {
                 Page = new CustomisingADayExamplePage(),
-                Title = $"Customising A Day",
-                Description = $"How to customise the appearance of a day in {nameof(CalendarView)}.",
+                Title = "Customising A Day",
+                Description = "How to customise the appearance of a day in {nameof(CalendarView)}.",
                 Tags = new List<Tag>()
                 {
                     new Tag() { Title = "DayTemplate" },
@@ -69,8 +69,8 @@ namespace XCalendarFormsSample.ViewModels
             new Example()
             {
                 Page = new SwipableCalendarExamplePage(),
-                Title = $"Animated Swipable Calendar",
-                Description = $"How to create a Calendar where swiping navigates the calendar and shows a preview of the previous or next page.",
+                Title = "Animated Swipable Calendar",
+                Description = "How to create a Calendar where swiping navigates the calendar and shows a preview of the previous or next page.",
                 Tags = new List<Tag>()
                 {
                     new Tag() { Title = "Swipe" },
@@ -90,7 +90,7 @@ namespace XCalendarFormsSample.ViewModels
             {
                 Page = new ConnectingSelectedDaysExamplePage(),
                 Title = "Connecting Selected Days",
-                Description = $"Implementation of connecting consecutively selected days.",
+                Description = "Implementation of connecting consecutively selected days.",
                 Tags = new List<Tag>()
                 {
                     new Tag() { Title = "Span" },
@@ -110,7 +110,7 @@ namespace XCalendarFormsSample.ViewModels
             new Example()
             {
                 Page = new DuolingoStreakCalendarExamplePage(),
-                Title = "Duolingo Calendar",
+                Title = "Duolingo Streak Calendar",
                 Description = "Implementation of the streak calendar in the 'Duolingo' app.",
                 Tags = new List<Tag>()
                 {

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/DuolingoStreakCalendarExamplePage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/DuolingoStreakCalendarExamplePage.xaml
@@ -139,11 +139,12 @@
                                         </xc:DayView.TodayStyle>
 
                                         <xc:DayView.Triggers>
-
+                                            <!--  Perfect Week  -->
                                             <MultiTrigger TargetType="{x:Type xc:DayView}">
                                                 <MultiTrigger.Conditions>
                                                     <BindingCondition Binding="{Binding IsInsidePerfectWeek}" Value="True"/>
                                                     <BindingCondition Binding="{Binding DailyGoalAchieved}" Value="True"/>
+                                                    <BindingCondition Binding="{Binding IsCurrentMonth}" Value="True"/>
                                                 </MultiTrigger.Conditions>
 
                                                 <Setter Property="Style">
@@ -160,8 +161,29 @@
 
                                             <MultiTrigger TargetType="{x:Type xc:DayView}">
                                                 <MultiTrigger.Conditions>
+                                                    <BindingCondition Binding="{Binding IsInsidePerfectWeek}" Value="True"/>
+                                                    <BindingCondition Binding="{Binding DailyGoalAchieved}" Value="True"/>
+                                                    <BindingCondition Binding="{Binding IsCurrentMonth}" Value="False"/>
+                                                </MultiTrigger.Conditions>
+
+                                                <Setter Property="Style">
+                                                    <Setter.Value>
+                                                        <Style TargetType="{x:Type xc:DayView}">
+                                                            <Setter Property="Command" Value="{Binding BindingContext.ToggleDayCommand, Source={x:Reference This}}"/>
+                                                            <Setter Property="BackgroundColor" Value="{StaticResource DuolingoCalendarWeekStreakBackgroundColor}"/>
+                                                            <Setter Property="TextColor" Value="Transparent"/>
+                                                        </Style>
+                                                    </Setter.Value>
+                                                </Setter>
+
+                                            </MultiTrigger>
+
+                                            <!--  Not Perfect Week  -->
+                                            <MultiTrigger TargetType="{x:Type xc:DayView}">
+                                                <MultiTrigger.Conditions>
                                                     <BindingCondition Binding="{Binding DailyGoalAchieved}" Value="True"/>
                                                     <BindingCondition Binding="{Binding IsInsidePerfectWeek}" Value="False"/>
+                                                    <BindingCondition Binding="{Binding IsCurrentMonth}" Value="True"/>
                                                 </MultiTrigger.Conditions>
 
                                                 <Setter Property="Style">
@@ -176,6 +198,25 @@
 
                                             </MultiTrigger>
 
+                                            <MultiTrigger TargetType="{x:Type xc:DayView}">
+                                                <MultiTrigger.Conditions>
+                                                    <BindingCondition Binding="{Binding DailyGoalAchieved}" Value="True"/>
+                                                    <BindingCondition Binding="{Binding IsInsidePerfectWeek}" Value="False"/>
+                                                    <BindingCondition Binding="{Binding IsCurrentMonth}" Value="False"/>
+                                                </MultiTrigger.Conditions>
+
+                                                <Setter Property="Style">
+                                                    <Setter.Value>
+                                                        <Style TargetType="{x:Type xc:DayView}">
+                                                            <Setter Property="BackgroundColor" Value="{StaticResource DuolingoCalendarStreakBackgroundColor}"/>
+                                                            <Setter Property="TextColor" Value="Transparent"/>
+                                                        </Style>
+                                                    </Setter.Value>
+                                                </Setter>
+
+                                            </MultiTrigger>
+
+                                            <!--  Streak Freeze  -->
                                             <DataTrigger
                                                 Binding="{Binding StreakFreezeUsed}"
                                                 TargetType="{x:Type xc:DayView}"

--- a/XCalendarMauiSample/ViewModels/DuolingoStreakCalendarExampleViewModel.cs
+++ b/XCalendarMauiSample/ViewModels/DuolingoStreakCalendarExampleViewModel.cs
@@ -85,13 +85,38 @@ namespace XCalendarMauiSample.ViewModels
                 }
             }
 
+            DateTime firstDayOfMonth = Calendar.NavigatedDate.FirstDayOfMonth();
+            DateTime lastDayOfMonth = Calendar.NavigatedDate.LastDayOfMonth();
+            DateTime lastDayOfPreviousMonth = firstDayOfMonth.AddDays(-1);
+            DateTime firstDayOfNextMonth = lastDayOfMonth.AddDays(1);
+
             for (int i = 0; i < Calendar.Days.Count; i++)
             {
                 DuolingoDay day = Calendar.Days[i];
 
-                day.IsInsidePerfectWeek = datesInsidePerfectWeek.Any(x => x.Date == day.DateTime.Date);
-                day.DailyGoalAchieved = DatesWhenGoalWasAchieved.Any(x => x.Date == day.DateTime.Date);
-                day.StreakFreezeUsed = DatesWhenStreakFreezeWasUsed.Any(x => x.Date == day.DateTime.Date);
+                //Days outside the month should be connected if the first day of the current month connects to the last day of the previous month or
+                //the last day of the current month connects to the first day of the next month.
+
+                if (day.DateTime.Date < firstDayOfMonth.Date)
+                {
+                    day.IsInsidePerfectWeek = datesInsidePerfectWeek.Any(x => x.Date == firstDayOfMonth.Date) && datesInsidePerfectWeek.Any(x => x.Date == lastDayOfPreviousMonth.Date);
+                    day.DailyGoalAchieved = (DatesWhenGoalWasAchieved.Any(x => x.Date == firstDayOfMonth.Date) || DatesWhenStreakFreezeWasUsed.Any(x => x.Date == firstDayOfMonth.Date))
+                        && (DatesWhenGoalWasAchieved.Any(x => x.Date == lastDayOfPreviousMonth.Date) || DatesWhenStreakFreezeWasUsed.Any(x => x.Date == lastDayOfPreviousMonth.Date));
+                    day.StreakFreezeUsed = false;
+                }
+                else if (day.DateTime.Date > lastDayOfMonth.Date)
+                {
+                    day.IsInsidePerfectWeek = datesInsidePerfectWeek.Any(x => x.Date == lastDayOfMonth.Date) && datesInsidePerfectWeek.Any(x => x.Date == firstDayOfNextMonth.Date);
+                    day.DailyGoalAchieved = (DatesWhenGoalWasAchieved.Any(x => x.Date == lastDayOfMonth.Date) || DatesWhenStreakFreezeWasUsed.Any(x => x.Date == lastDayOfMonth.Date))
+                        && (DatesWhenGoalWasAchieved.Any(x => x.Date == firstDayOfNextMonth.Date) || DatesWhenStreakFreezeWasUsed.Any(x => x.Date == firstDayOfNextMonth.Date));
+                    day.StreakFreezeUsed = false;
+                }
+                else
+                {
+                    day.IsInsidePerfectWeek = datesInsidePerfectWeek.Any(x => x.Date == day.DateTime.Date);
+                    day.DailyGoalAchieved = DatesWhenGoalWasAchieved.Any(x => x.Date == day.DateTime.Date);
+                    day.StreakFreezeUsed = DatesWhenStreakFreezeWasUsed.Any(x => x.Date == day.DateTime.Date);
+                }
             }
 
             for (int i = 0; i < Calendar.Days.Count; i++)

--- a/XCalendarMauiSample/ViewModels/ExamplesViewModel.cs
+++ b/XCalendarMauiSample/ViewModels/ExamplesViewModel.cs
@@ -30,19 +30,19 @@ namespace XCalendarMauiSample.ViewModels
             {
                 Page = new CustomDatePickerDialogExamplePage(),
                 Title = "Custom DatePicker Dialog",
-                Description = $"A custom DatePicker made using a {nameof(CalendarView)}."
+                Description = "A custom DatePicker made using a {nameof(CalendarView)}."
             },
             new Example()
             {
                 Page = new SelectionExamplePage(),
                 Title = "Date Selection",
-                Description = $"Showcase of {nameof(CalendarView)}'s selection capabilities."
+                Description = "Showcase of {nameof(CalendarView)}'s selection capabilities."
             },
             new Example()
             {
                 Page = new UsingDayViewExamplePage(),
-                Title = $"Using {nameof(DayView)}",
-                Description = $"How to use the {nameof(DayView)} control.",
+                Title = "Using {nameof(DayView)}",
+                Description = "How to use the {nameof(DayView)} control.",
                 Tags = new List<Tag>()
                 {
                     new Tag() { Title = "DayTemplate" },
@@ -53,8 +53,8 @@ namespace XCalendarMauiSample.ViewModels
             new Example()
             {
                 Page = new CustomisingADayExamplePage(),
-                Title = $"Customising A Day",
-                Description = $"How to customise the appearance of a day in {nameof(CalendarView)}.",
+                Title = "Customising A Day",
+                Description = "How to customise the appearance of a day in {nameof(CalendarView)}.",
                 Tags = new List<Tag>()
                 {
                     new Tag() { Title = "DayTemplate" },
@@ -65,8 +65,8 @@ namespace XCalendarMauiSample.ViewModels
             new Example()
             {
                 Page = new SwipableCalendarExamplePage(),
-                Title = $"Animated Swipable Calendar",
-                Description = $"How to create a Calendar where swiping navigates the calendar and shows a preview of the previous or next page.",
+                Title = "Animated Swipable Calendar",
+                Description = "How to create a Calendar where swiping navigates the calendar and shows a preview of the previous or next page.",
                 Tags = new List<Tag>()
                 {
                     new Tag() { Title = "Swipe" },
@@ -86,7 +86,7 @@ namespace XCalendarMauiSample.ViewModels
             {
                 Page = new ConnectingSelectedDaysExamplePage(),
                 Title = "Connecting Selected Days",
-                Description = $"Implementation of connecting consecutively selected days.",
+                Description = "Implementation of connecting consecutively selected days.",
                 Tags = new List<Tag>()
                 {
                     new Tag() { Title = "Span" },
@@ -106,7 +106,7 @@ namespace XCalendarMauiSample.ViewModels
             new Example()
             {
                 Page = new DuolingoStreakCalendarExamplePage(),
-                Title = "Duolingo Calendar",
+                Title = "Duolingo Streak Calendar",
                 Description = "Implementation of the streak calendar in the 'Duolingo' app.",
                 Tags = new List<Tag>()
                 {

--- a/XCalendarMauiSample/Views/DuolingoStreakCalendarExamplePage.xaml
+++ b/XCalendarMauiSample/Views/DuolingoStreakCalendarExamplePage.xaml
@@ -142,11 +142,12 @@
                                     </xc:DayView.TodayStyle>
 
                                     <xc:DayView.Triggers>
-
+                                        <!--  Perfect Week  -->
                                         <MultiTrigger TargetType="{x:Type xc:DayView}">
                                             <MultiTrigger.Conditions>
                                                 <BindingCondition Binding="{Binding IsInsidePerfectWeek}" Value="True"/>
                                                 <BindingCondition Binding="{Binding DailyGoalAchieved}" Value="True"/>
+                                                <BindingCondition Binding="{Binding IsCurrentMonth}" Value="True"/>
                                             </MultiTrigger.Conditions>
 
                                             <Setter Property="Style">
@@ -163,8 +164,29 @@
 
                                         <MultiTrigger TargetType="{x:Type xc:DayView}">
                                             <MultiTrigger.Conditions>
+                                                <BindingCondition Binding="{Binding IsInsidePerfectWeek}" Value="True"/>
+                                                <BindingCondition Binding="{Binding DailyGoalAchieved}" Value="True"/>
+                                                <BindingCondition Binding="{Binding IsCurrentMonth}" Value="False"/>
+                                            </MultiTrigger.Conditions>
+
+                                            <Setter Property="Style">
+                                                <Setter.Value>
+                                                    <Style TargetType="{x:Type xc:DayView}">
+                                                        <Setter Property="Command" Value="{Binding BindingContext.ToggleDayCommand, Source={x:Reference This}}"/>
+                                                        <Setter Property="BackgroundColor" Value="{StaticResource DuolingoCalendarWeekStreakBackgroundColor}"/>
+                                                        <Setter Property="TextColor" Value="Transparent"/>
+                                                    </Style>
+                                                </Setter.Value>
+                                            </Setter>
+
+                                        </MultiTrigger>
+
+                                        <!--  Not Perfect Week  -->
+                                        <MultiTrigger TargetType="{x:Type xc:DayView}">
+                                            <MultiTrigger.Conditions>
                                                 <BindingCondition Binding="{Binding DailyGoalAchieved}" Value="True"/>
                                                 <BindingCondition Binding="{Binding IsInsidePerfectWeek}" Value="False"/>
+                                                <BindingCondition Binding="{Binding IsCurrentMonth}" Value="True"/>
                                             </MultiTrigger.Conditions>
 
                                             <Setter Property="Style">
@@ -179,6 +201,25 @@
 
                                         </MultiTrigger>
 
+                                        <MultiTrigger TargetType="{x:Type xc:DayView}">
+                                            <MultiTrigger.Conditions>
+                                                <BindingCondition Binding="{Binding DailyGoalAchieved}" Value="True"/>
+                                                <BindingCondition Binding="{Binding IsInsidePerfectWeek}" Value="False"/>
+                                                <BindingCondition Binding="{Binding IsCurrentMonth}" Value="False"/>
+                                            </MultiTrigger.Conditions>
+
+                                            <Setter Property="Style">
+                                                <Setter.Value>
+                                                    <Style TargetType="{x:Type xc:DayView}">
+                                                        <Setter Property="BackgroundColor" Value="{StaticResource DuolingoCalendarStreakBackgroundColor}"/>
+                                                        <Setter Property="TextColor" Value="Transparent"/>
+                                                    </Style>
+                                                </Setter.Value>
+                                            </Setter>
+
+                                        </MultiTrigger>
+
+                                        <!--  Streak Freeze  -->
                                         <DataTrigger
                                             Binding="{Binding StreakFreezeUsed}"
                                             TargetType="{x:Type xc:DayView}"


### PR DESCRIPTION
The calendar now fully matches the visual behaviour in the real Duolingo app.