### PR TITLE
Revert "Fix DuolingoStreakCalendar example to not joining the streak background across OtherMonth days"

### DIFF
--- a/XCalendarFormsSample/XCalendarFormsSample/ViewModels/DuolingoStreakCalendarExampleViewModel.cs
+++ b/XCalendarFormsSample/XCalendarFormsSample/ViewModels/DuolingoStreakCalendarExampleViewModel.cs
@@ -89,38 +89,13 @@ namespace XCalendarFormsSample.ViewModels
                 }
             }
 
-            DateTime firstDayOfMonth = Calendar.NavigatedDate.FirstDayOfMonth();
-            DateTime lastDayOfMonth = Calendar.NavigatedDate.LastDayOfMonth();
-            DateTime lastDayOfPreviousMonth = firstDayOfMonth.AddDays(-1);
-            DateTime firstDayOfNextMonth = lastDayOfMonth.AddDays(1);
-
             for (int i = 0; i < Calendar.Days.Count; i++)
             {
                 DuolingoDay day = Calendar.Days[i];
 
-                //Days outside the month should be connected if the first day of the current month connects to the last day of the previous month or
-                //the last day of the current month connects to the first day of the next month.
-
-                if (day.DateTime.Date < firstDayOfMonth.Date)
-                {
-                    day.IsInsidePerfectWeek = datesInsidePerfectWeek.Any(x => x.Date == firstDayOfMonth.Date) && datesInsidePerfectWeek.Any(x => x.Date == lastDayOfPreviousMonth.Date);
-                    day.DailyGoalAchieved = (DatesWhenGoalWasAchieved.Any(x => x.Date == firstDayOfMonth.Date) || DatesWhenStreakFreezeWasUsed.Any(x => x.Date == firstDayOfMonth.Date))
-                        && (DatesWhenGoalWasAchieved.Any(x => x.Date == lastDayOfPreviousMonth.Date) || DatesWhenStreakFreezeWasUsed.Any(x => x.Date == lastDayOfPreviousMonth.Date));
-                    day.StreakFreezeUsed = false;
-                }
-                else if (day.DateTime.Date > lastDayOfMonth.Date)
-                {
-                    day.IsInsidePerfectWeek = datesInsidePerfectWeek.Any(x => x.Date == lastDayOfMonth.Date) && datesInsidePerfectWeek.Any(x => x.Date == firstDayOfNextMonth.Date);
-                    day.DailyGoalAchieved = (DatesWhenGoalWasAchieved.Any(x => x.Date == lastDayOfMonth.Date) || DatesWhenStreakFreezeWasUsed.Any(x => x.Date == lastDayOfMonth.Date))
-                        && (DatesWhenGoalWasAchieved.Any(x => x.Date == firstDayOfNextMonth.Date) || DatesWhenStreakFreezeWasUsed.Any(x => x.Date == firstDayOfNextMonth.Date));
-                    day.StreakFreezeUsed = false;
-                }
-                else
-                {
-                    day.IsInsidePerfectWeek = datesInsidePerfectWeek.Any(x => x.Date == day.DateTime.Date);
-                    day.DailyGoalAchieved = DatesWhenGoalWasAchieved.Any(x => x.Date == day.DateTime.Date);
-                    day.StreakFreezeUsed = DatesWhenStreakFreezeWasUsed.Any(x => x.Date == day.DateTime.Date);
-                }
+                day.IsInsidePerfectWeek = datesInsidePerfectWeek.Any(x => x.Date == day.DateTime.Date);
+                day.DailyGoalAchieved = DatesWhenGoalWasAchieved.Any(x => x.Date == day.DateTime.Date);
+                day.StreakFreezeUsed = DatesWhenStreakFreezeWasUsed.Any(x => x.Date == day.DateTime.Date);
             }
 
             for (int i = 0; i < Calendar.Days.Count; i++)

--- a/XCalendarFormsSample/XCalendarFormsSample/Views/DuolingoStreakCalendarExamplePage.xaml
+++ b/XCalendarFormsSample/XCalendarFormsSample/Views/DuolingoStreakCalendarExamplePage.xaml
@@ -139,12 +139,11 @@
                                         </xc:DayView.TodayStyle>
 
                                         <xc:DayView.Triggers>
-                                            <!--  Perfect Week  -->
+
                                             <MultiTrigger TargetType="{x:Type xc:DayView}">
                                                 <MultiTrigger.Conditions>
                                                     <BindingCondition Binding="{Binding IsInsidePerfectWeek}" Value="True"/>
                                                     <BindingCondition Binding="{Binding DailyGoalAchieved}" Value="True"/>
-                                                    <BindingCondition Binding="{Binding IsCurrentMonth}" Value="True"/>
                                                 </MultiTrigger.Conditions>
 
                                                 <Setter Property="Style">
@@ -161,29 +160,8 @@
 
                                             <MultiTrigger TargetType="{x:Type xc:DayView}">
                                                 <MultiTrigger.Conditions>
-                                                    <BindingCondition Binding="{Binding IsInsidePerfectWeek}" Value="True"/>
-                                                    <BindingCondition Binding="{Binding DailyGoalAchieved}" Value="True"/>
-                                                    <BindingCondition Binding="{Binding IsCurrentMonth}" Value="False"/>
-                                                </MultiTrigger.Conditions>
-
-                                                <Setter Property="Style">
-                                                    <Setter.Value>
-                                                        <Style TargetType="{x:Type xc:DayView}">
-                                                            <Setter Property="Command" Value="{Binding BindingContext.ToggleDayCommand, Source={x:Reference This}}"/>
-                                                            <Setter Property="BackgroundColor" Value="{StaticResource DuolingoCalendarWeekStreakBackgroundColor}"/>
-                                                            <Setter Property="TextColor" Value="Transparent"/>
-                                                        </Style>
-                                                    </Setter.Value>
-                                                </Setter>
-
-                                            </MultiTrigger>
-
-                                            <!--  Not Perfect Week  -->
-                                            <MultiTrigger TargetType="{x:Type xc:DayView}">
-                                                <MultiTrigger.Conditions>
                                                     <BindingCondition Binding="{Binding DailyGoalAchieved}" Value="True"/>
                                                     <BindingCondition Binding="{Binding IsInsidePerfectWeek}" Value="False"/>
-                                                    <BindingCondition Binding="{Binding IsCurrentMonth}" Value="True"/>
                                                 </MultiTrigger.Conditions>
 
                                                 <Setter Property="Style">
@@ -198,25 +176,6 @@
 
                                             </MultiTrigger>
 
-                                            <MultiTrigger TargetType="{x:Type xc:DayView}">
-                                                <MultiTrigger.Conditions>
-                                                    <BindingCondition Binding="{Binding DailyGoalAchieved}" Value="True"/>
-                                                    <BindingCondition Binding="{Binding IsInsidePerfectWeek}" Value="False"/>
-                                                    <BindingCondition Binding="{Binding IsCurrentMonth}" Value="False"/>
-                                                </MultiTrigger.Conditions>
-
-                                                <Setter Property="Style">
-                                                    <Setter.Value>
-                                                        <Style TargetType="{x:Type xc:DayView}">
-                                                            <Setter Property="BackgroundColor" Value="{StaticResource DuolingoCalendarStreakBackgroundColor}"/>
-                                                            <Setter Property="TextColor" Value="Transparent"/>
-                                                        </Style>
-                                                    </Setter.Value>
-                                                </Setter>
-
-                                            </MultiTrigger>
-
-                                            <!--  Streak Freeze  -->
                                             <DataTrigger
                                                 Binding="{Binding StreakFreezeUsed}"
                                                 TargetType="{x:Type xc:DayView}"

--- a/XCalendarMauiSample/ViewModels/DuolingoStreakCalendarExampleViewModel.cs
+++ b/XCalendarMauiSample/ViewModels/DuolingoStreakCalendarExampleViewModel.cs
@@ -85,38 +85,13 @@ namespace XCalendarMauiSample.ViewModels
                 }
             }
 
-            DateTime firstDayOfMonth = Calendar.NavigatedDate.FirstDayOfMonth();
-            DateTime lastDayOfMonth = Calendar.NavigatedDate.LastDayOfMonth();
-            DateTime lastDayOfPreviousMonth = firstDayOfMonth.AddDays(-1);
-            DateTime firstDayOfNextMonth = lastDayOfMonth.AddDays(1);
-
             for (int i = 0; i < Calendar.Days.Count; i++)
             {
                 DuolingoDay day = Calendar.Days[i];
 
-                //Days outside the month should be connected if the first day of the current month connects to the last day of the previous month or
-                //the last day of the current month connects to the first day of the next month.
-
-                if (day.DateTime.Date < firstDayOfMonth.Date)
-                {
-                    day.IsInsidePerfectWeek = datesInsidePerfectWeek.Any(x => x.Date == firstDayOfMonth.Date) && datesInsidePerfectWeek.Any(x => x.Date == lastDayOfPreviousMonth.Date);
-                    day.DailyGoalAchieved = (DatesWhenGoalWasAchieved.Any(x => x.Date == firstDayOfMonth.Date) || DatesWhenStreakFreezeWasUsed.Any(x => x.Date == firstDayOfMonth.Date))
-                        && (DatesWhenGoalWasAchieved.Any(x => x.Date == lastDayOfPreviousMonth.Date) || DatesWhenStreakFreezeWasUsed.Any(x => x.Date == lastDayOfPreviousMonth.Date));
-                    day.StreakFreezeUsed = false;
-                }
-                else if (day.DateTime.Date > lastDayOfMonth.Date)
-                {
-                    day.IsInsidePerfectWeek = datesInsidePerfectWeek.Any(x => x.Date == lastDayOfMonth.Date) && datesInsidePerfectWeek.Any(x => x.Date == firstDayOfNextMonth.Date);
-                    day.DailyGoalAchieved = (DatesWhenGoalWasAchieved.Any(x => x.Date == lastDayOfMonth.Date) || DatesWhenStreakFreezeWasUsed.Any(x => x.Date == lastDayOfMonth.Date))
-                        && (DatesWhenGoalWasAchieved.Any(x => x.Date == firstDayOfNextMonth.Date) || DatesWhenStreakFreezeWasUsed.Any(x => x.Date == firstDayOfNextMonth.Date));
-                    day.StreakFreezeUsed = false;
-                }
-                else
-                {
-                    day.IsInsidePerfectWeek = datesInsidePerfectWeek.Any(x => x.Date == day.DateTime.Date);
-                    day.DailyGoalAchieved = DatesWhenGoalWasAchieved.Any(x => x.Date == day.DateTime.Date);
-                    day.StreakFreezeUsed = DatesWhenStreakFreezeWasUsed.Any(x => x.Date == day.DateTime.Date);
-                }
+                day.IsInsidePerfectWeek = datesInsidePerfectWeek.Any(x => x.Date == day.DateTime.Date);
+                day.DailyGoalAchieved = DatesWhenGoalWasAchieved.Any(x => x.Date == day.DateTime.Date);
+                day.StreakFreezeUsed = DatesWhenStreakFreezeWasUsed.Any(x => x.Date == day.DateTime.Date);
             }
 
             for (int i = 0; i < Calendar.Days.Count; i++)

--- a/XCalendarMauiSample/Views/DuolingoStreakCalendarExamplePage.xaml
+++ b/XCalendarMauiSample/Views/DuolingoStreakCalendarExamplePage.xaml
@@ -142,12 +142,11 @@
                                     </xc:DayView.TodayStyle>
 
                                     <xc:DayView.Triggers>
-                                        <!--  Perfect Week  -->
+
                                         <MultiTrigger TargetType="{x:Type xc:DayView}">
                                             <MultiTrigger.Conditions>
                                                 <BindingCondition Binding="{Binding IsInsidePerfectWeek}" Value="True"/>
                                                 <BindingCondition Binding="{Binding DailyGoalAchieved}" Value="True"/>
-                                                <BindingCondition Binding="{Binding IsCurrentMonth}" Value="True"/>
                                             </MultiTrigger.Conditions>
 
                                             <Setter Property="Style">
@@ -164,29 +163,8 @@
 
                                         <MultiTrigger TargetType="{x:Type xc:DayView}">
                                             <MultiTrigger.Conditions>
-                                                <BindingCondition Binding="{Binding IsInsidePerfectWeek}" Value="True"/>
-                                                <BindingCondition Binding="{Binding DailyGoalAchieved}" Value="True"/>
-                                                <BindingCondition Binding="{Binding IsCurrentMonth}" Value="False"/>
-                                            </MultiTrigger.Conditions>
-
-                                            <Setter Property="Style">
-                                                <Setter.Value>
-                                                    <Style TargetType="{x:Type xc:DayView}">
-                                                        <Setter Property="Command" Value="{Binding BindingContext.ToggleDayCommand, Source={x:Reference This}}"/>
-                                                        <Setter Property="BackgroundColor" Value="{StaticResource DuolingoCalendarWeekStreakBackgroundColor}"/>
-                                                        <Setter Property="TextColor" Value="Transparent"/>
-                                                    </Style>
-                                                </Setter.Value>
-                                            </Setter>
-
-                                        </MultiTrigger>
-
-                                        <!--  Not Perfect Week  -->
-                                        <MultiTrigger TargetType="{x:Type xc:DayView}">
-                                            <MultiTrigger.Conditions>
                                                 <BindingCondition Binding="{Binding DailyGoalAchieved}" Value="True"/>
                                                 <BindingCondition Binding="{Binding IsInsidePerfectWeek}" Value="False"/>
-                                                <BindingCondition Binding="{Binding IsCurrentMonth}" Value="True"/>
                                             </MultiTrigger.Conditions>
 
                                             <Setter Property="Style">
@@ -201,25 +179,6 @@
 
                                         </MultiTrigger>
 
-                                        <MultiTrigger TargetType="{x:Type xc:DayView}">
-                                            <MultiTrigger.Conditions>
-                                                <BindingCondition Binding="{Binding DailyGoalAchieved}" Value="True"/>
-                                                <BindingCondition Binding="{Binding IsInsidePerfectWeek}" Value="False"/>
-                                                <BindingCondition Binding="{Binding IsCurrentMonth}" Value="False"/>
-                                            </MultiTrigger.Conditions>
-
-                                            <Setter Property="Style">
-                                                <Setter.Value>
-                                                    <Style TargetType="{x:Type xc:DayView}">
-                                                        <Setter Property="BackgroundColor" Value="{StaticResource DuolingoCalendarStreakBackgroundColor}"/>
-                                                        <Setter Property="TextColor" Value="Transparent"/>
-                                                    </Style>
-                                                </Setter.Value>
-                                            </Setter>
-
-                                        </MultiTrigger>
-
-                                        <!--  Streak Freeze  -->
                                         <DataTrigger
                                             Binding="{Binding StreakFreezeUsed}"
                                             TargetType="{x:Type xc:DayView}"


### PR DESCRIPTION
This reverts commit 4cbd7c4c5c63e700c0f8a17dbdbf57b8bcd256ef.

Visual bugs were found which were caused by the triggers that were added. These bugs would occurr when having a few days selected and switching between months.