### PR TITLE
Fix DateTimeExtensions tests failing due to culture-specific parameters not being passed

### DIFF
--- a/XCalendar.Core.Tests/Extensions/DateTimeExtensionsTests.cs
+++ b/XCalendar.Core.Tests/Extensions/DateTimeExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using XCalendar.Core.Extensions;
 using Xunit;
 
@@ -38,44 +39,44 @@ namespace XCalendar.Core.Tests.Extensions
         }
 
         [Theory]
-        [InlineData(2023, 9, 15, 2023, 9, 10)]
-        [InlineData(2024, 1, 7, 2024, 1, 7)]
-        [InlineData(2022, 12, 25, 2022, 12, 25)]
+        [InlineData(2023, 9, 15, DayOfWeek.Sunday, 2023, 9, 10)]
+        [InlineData(2024, 1, 7, DayOfWeek.Sunday, 2024, 1, 7)]
+        [InlineData(2022, 12, 25, DayOfWeek.Sunday, 2022, 12, 25)]
         public void FirstDayOfWeekShouldReturnCorrectDate(
-            int year, int month, int day,
+            int year, int month, int day, DayOfWeek dayOfWeek,
             int expectedYear, int expectedMonth, int expectedDay)
         {
             var date = new DateTime(year, month, day);
 
-            var result = date.FirstDayOfWeek();
+            var result = date.FirstDayOfWeek(dayOfWeek);
 
             Assert.Equal(new DateTime(expectedYear, expectedMonth, expectedDay), result);
         }
 
         [Theory]
-        [InlineData(2023, 9, 15, 2023, 9, 16)]
-        [InlineData(2024, 1, 7, 2024, 1, 13)]
-        [InlineData(2022, 12, 25, 2022, 12, 31)]
+        [InlineData(2023, 9, 15, DayOfWeek.Sunday, 2023, 9, 16)]
+        [InlineData(2024, 1, 7, DayOfWeek.Sunday, 2024, 1, 13)]
+        [InlineData(2022, 12, 25, DayOfWeek.Sunday, 2022, 12, 31)]
         public void LastDayOfWeekShouldReturnCorrectDate(
-            int year, int month, int day,
+            int year, int month, int day, DayOfWeek dayOfWeek,
             int expectedYear, int expectedMonth, int expectedDay)
         {
             var date = new DateTime(year, month, day);
 
-            var result = date.LastDayOfWeek();
+            var result = date.LastDayOfWeek(dayOfWeek);
 
             Assert.Equal(new DateTime(expectedYear, expectedMonth, expectedDay), result);
         }
 
         [Theory]
-        [InlineData(2023, 9, 15, 3)]
-        [InlineData(2024, 1, 7, 2)]
-        [InlineData(2022, 12, 25, 5)]
-        public void CalendarWeekOfMonthShouldReturnCorrectWeek(int year, int month, int day, int expectedWeekOfMonth)
+        [InlineData(2023, 9, 15, DayOfWeek.Sunday, 3)]
+        [InlineData(2024, 1, 7, DayOfWeek.Sunday, 2)]
+        [InlineData(2022, 12, 25, DayOfWeek.Sunday, 5)]
+        public void CalendarWeekOfMonthShouldReturnCorrectWeek(int year, int month, int day, DayOfWeek dayOfWeek, int expectedWeekOfMonth)
         {
             var date = new DateTime(year, month, day);
 
-            var result = date.CalendarWeekOfMonth();
+            var result = date.CalendarWeekOfMonth(dayOfWeek);
 
             Assert.Equal(expectedWeekOfMonth, result);
         }


### PR DESCRIPTION
Methods such as `FirstDayOfWeek` specify an optional parameter "startingDayOfWeek" of type `DayOfWeek` which affects the result of the calculation. If this isn't specified, it uses `CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek` which could vary depending on what machine the tests are run on.

Since the result varies with the machine's culture but the inputs don't, and the tests were created on a machine using a culture with a different start of week than mine, the tests failed.

Added an additional parameter to the test inputs and set the inputs to `DayOfWeek.Sunday` since the tests passed when `CultureInfo.InvariantCulture.DateTimeFormat.FirstDayOfWeek` was passed and that was its value.