### PR TITLE
Remove method "Localize" from DateTimeExtensions

### DIFF
--- a/XCalendar.Core/Extensions/DayOfWeekExtensions.cs
+++ b/XCalendar.Core/Extensions/DayOfWeekExtensions.cs
@@ -56,11 +56,6 @@ namespace XCalendar.Core.Extensions
 
             return week;
         }
-
-        public static string Localize(this DayOfWeek self, CultureInfo culture)
-        {
-            return culture.DateTimeFormat.GetDayName(self);
-        }
         #endregion
     }
 }

--- a/XCalendar.Forms/Converters/LocalizeDayOfWeekAndCharLimitConverter.cs
+++ b/XCalendar.Forms/Converters/LocalizeDayOfWeekAndCharLimitConverter.cs
@@ -14,7 +14,8 @@ namespace XCalendar.Forms.Converters
                 return string.Empty;
             }
 
-            return dayOfWeek.Localize(culture)
+            return culture.DateTimeFormat
+                .GetDayName(dayOfWeek)
                 .TruncateStringToMaxLength(parameter)
                 .ToTitleCase(culture);
         }

--- a/XCalendar.Maui/Converters/LocalizeDayOfWeekAndCharLimitConverter.cs
+++ b/XCalendar.Maui/Converters/LocalizeDayOfWeekAndCharLimitConverter.cs
@@ -12,7 +12,8 @@ namespace XCalendar.Maui.Converters
                 return string.Empty;
             }
 
-            return dayOfWeek.Localize(culture)
+            return culture.DateTimeFormat
+                .GetDayName(dayOfWeek)
                 .TruncateStringToMaxLength(parameter)
                 .ToTitleCase(culture);
         }


### PR DESCRIPTION
This method is now redundant since it only calls the methods from the parameters that are passed. Both the extension method and its implementation would only take one line of code to use.